### PR TITLE
fix: remove id-token permission from claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,6 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Remove `id-token: write` permission from claude-code-review workflow to fix OIDC authentication conflicts

## Problem
The Claude Code review action was failing with:
```
Error: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

This occurred because the action was trying to use both OIDC authentication (due to `id-token: write` permission) and OAuth token authentication (`claude_code_oauth_token` secret) simultaneously, causing a conflict.

## Solution
Removed the `id-token: write` permission so the action uses only OAuth token authentication via the existing `CLAUDE_CODE_OAUTH_TOKEN` secret.

## Test plan
- [x] Workflow syntax is valid (pre-commit hooks passed)
- [ ] Test the workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.ai/code)