### PR TITLE
Fix inconsistent schema title casing

### DIFF
--- a/blueprint/cli.py
+++ b/blueprint/cli.py
@@ -213,7 +213,6 @@ def _get_registry(template_dir: str | None) -> BlueprintRegistry:
 def _build_version_schema(
     blueprint_name: str,
     version: int,
-    base_name: str,
     raw_schema: dict,
 ) -> dict:
     """Build a schema variant for a single version of a blueprint."""
@@ -239,7 +238,7 @@ def _build_version_schema(
     if "version" not in schema_data["required"]:
         schema_data["required"].insert(1, "version")
 
-    schema_data["title"] = base_name
+    schema_data["title"] = blueprint_name
     schema_data.pop("$schema", None)
 
     return schema_data
@@ -311,7 +310,6 @@ def schema(
             _build_version_schema(
                 blueprint_name,
                 vi["version"],
-                vi["base_name"],
                 vi["schema"],
             )
             for vi in versions_info

--- a/blueprint/registry.py
+++ b/blueprint/registry.py
@@ -3,7 +3,6 @@
 import importlib.util
 import logging
 import os
-import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -302,7 +301,7 @@ class BlueprintRegistry:
 
         Returns:
             List of dicts sorted by version, each with version, class name,
-            base_name (class name without V{N} suffix), and schema.
+            and schema.
         """
         self.discover()
 
@@ -314,17 +313,10 @@ class BlueprintRegistry:
         for version in sorted(self._blueprints[name]):
             cls = self._blueprints[name][version]
 
-            base_class_name = cls.__name__
-            if "name" not in cls.__dict__:
-                version_match = re.match(r"^(.+?)V\d+$", base_class_name)
-                if version_match:
-                    base_class_name = version_match.group(1)
-
             result.append(
                 {
                     "version": version,
                     "class": cls.__name__,
-                    "base_name": base_class_name,
                     "schema": cls.get_schema(),
                 }
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 """Tests for the Blueprint CLI."""
 
+import json
+
 from click.testing import CliRunner
 
 from blueprint.cli import cli
@@ -378,6 +380,33 @@ class ExtV2(Blueprint[ExtV2Config]):
         result = runner.invoke(cli, ["schema", "ext", "--template-dir", str(template_dir)])
         assert result.exit_code == 0
         assert "oneOf" in result.output
-        output_lines = result.output.strip()
-        assert '"Ext"' in output_lines
-        assert '"ExtV2"' not in output_lines
+        schema = json.loads(result.output)
+        assert schema["title"] == "ext"
+        for variant in schema["oneOf"]:
+            assert variant["title"] == "ext"
+
+    def test_schema_title_with_explicit_name(self, tmp_path):
+        template_dir = tmp_path / "dags"
+        template_dir.mkdir()
+        (template_dir / "bp.py").write_text("""
+from pydantic import BaseModel
+from blueprint.core import Blueprint
+
+class MyCustomConfig(BaseModel):
+    x: int = 1
+
+class MyCustomClass(Blueprint[MyCustomConfig]):
+    name = "weather_ingest"
+
+    def render(self, config):
+        pass
+""")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["schema", "weather_ingest", "--template-dir", str(template_dir)]
+        )
+        assert result.exit_code == 0
+        schema = json.loads(result.output)
+        assert schema["title"] == "weather_ingest"
+        assert "MyCustomClass" not in result.output

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -261,7 +261,6 @@ class Dup(Blueprint[DupConfig2]):
         assert len(versions) == 1
         assert versions[0]["version"] == 1
         assert versions[0]["class"] == "Load"
-        assert versions[0]["base_name"] == "Load"
         assert "properties" in versions[0]["schema"]
         assert "$defs" not in versions[0]["schema"]
 
@@ -273,10 +272,8 @@ class Dup(Blueprint[DupConfig2]):
         assert len(versions) == 2
         assert versions[0]["version"] == 1
         assert versions[0]["class"] == "Extract"
-        assert versions[0]["base_name"] == "Extract"
         assert versions[1]["version"] == 2
         assert versions[1]["class"] == "ExtractV2"
-        assert versions[1]["base_name"] == "Extract"
 
     def test_get_all_versions_info_not_found(self, reg, temp_blueprints, monkeypatch):
         monkeypatch.setattr(reg, "get_template_dirs", lambda: [temp_blueprints])
@@ -426,8 +423,8 @@ class MyExtractorV2(Blueprint[Cfg2]):
 
         versions = reg.get_all_versions_info("extract")
         assert len(versions) == 2
-        assert versions[0]["base_name"] == "MyExtractorV1"
-        assert versions[1]["base_name"] == "MyExtractorV2"
+        assert versions[0]["class"] == "MyExtractorV1"
+        assert versions[1]["class"] == "MyExtractorV2"
 
 
 class TestDagArgsDiscovery:


### PR DESCRIPTION
## Summary
- Single-version blueprints used PascalCase class name as schema title (e.g. `"Extract"`) while multi-version used snake_case blueprint_name (e.g. `"scan"`)
- Now both consistently use `blueprint_name`, the canonical snake_case identifier
- Also respects explicit `name` overrides on blueprint classes

## Test plan
- [x] All 235 unit tests pass
- [x] All 76 integration tests pass
- [x] Lint and type checks pass
- [x] Manual CLI verification: `blueprint schema extract` and `blueprint schema scan` both produce snake_case titles
- [x] Verified bug reproduces on `main` before fix