### PR TITLE
Add trigger_rule support for step dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,11 @@ Reusable task group templates composed into Airflow DAGs via YAML.
 - **Create DAG interactively**: `uv run blueprint new`
 
 ## Testing
-- Run all tests: `uv run pytest tests/`
+- Run unit tests: `uv run pytest tests/ --ignore=tests/integration -v`
 - Run specific test: `uv run pytest tests/test_<module>.py`
 - Run with coverage: `uv run pytest --cov=blueprint tests/`
+- Run integration tests locally: `uv run pytest tests/integration/ -v` (requires Astro CLI — `astro version` to verify; starts a local Airflow instance via `astro dev start --standalone`, runs tests against the REST API, then tears down)
+- New features must include integration test coverage (`tests/integration/`) and be demonstrated in the advanced example (`examples/advanced/`)
 
 ## Code Style Guidelines
 - Follow Ruff configuration in `pyproject.toml`

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ steps:
     mode: overwrite
 ```
 
-Step config is flat -- `blueprint:`, `depends_on:`, and `version:` are reserved keys; everything else is passed to the blueprint's config model. Steps with no `depends_on` run in parallel.
+Step config is flat -- `blueprint:`, `depends_on:`, `version:`, and `trigger_rule:` are reserved keys; everything else is passed to the blueprint's config model. Steps with no `depends_on` run in parallel. Set `trigger_rule:` to control when a step runs relative to its upstream dependencies (e.g. `one_success`, `all_done`). The default is `all_success`. Valid values are determined by the installed Airflow version.
 
 The `blueprint:` value is the snake_case form of the class name. `Extract` becomes `extract`, `MultiSourceETL` becomes `multi_source_etl`. See [Template Versioning](#template-versioning) for details on how names and versions are determined.
 

--- a/blueprint/builder.py
+++ b/blueprint/builder.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from blueprint.core import TaskOrGroup
 from blueprint.errors import (
@@ -113,6 +113,20 @@ class StepConfig(BaseModel):
     blueprint: str
     depends_on: list[str] = Field(default_factory=list)
     version: int | None = None
+    trigger_rule: str | None = None
+
+    @field_validator("trigger_rule")
+    @classmethod
+    def validate_trigger_rule(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        from airflow.utils.trigger_rule import TriggerRule
+
+        if not TriggerRule.is_valid(v):
+            valid = sorted(str(r.value) for r in TriggerRule)
+            msg = f"Invalid trigger rule '{v}'. Valid values: {', '.join(valid)}"
+            raise ValueError(msg)
+        return v
 
     def get_blueprint_config(self) -> dict[str, Any]:
         """Get the blueprint-specific config (everything except reserved keys)."""
@@ -156,6 +170,21 @@ class Builder:
         self._registry = bp_registry or registry
         self._on_dag_built = on_dag_built
 
+    @staticmethod
+    def _ensure_start_date(dag_kwargs: dict[str, Any]) -> None:
+        """Set a default start_date or parse a string start_date."""
+        if "start_date" not in dag_kwargs:
+            dag_kwargs["start_date"] = DEFAULT_START_DATE
+        elif isinstance(dag_kwargs["start_date"], str):
+            try:
+                parsed = datetime.fromisoformat(dag_kwargs["start_date"])
+            except ValueError as e:
+                msg = f"Invalid start_date format: {dag_kwargs['start_date']!r}"
+                raise ConfigurationError(msg) from e
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            dag_kwargs["start_date"] = parsed
+
     def build(self, config: DAGConfig) -> "DAG":
         """Build a DAG from a DAGConfig.
 
@@ -185,17 +214,7 @@ class Builder:
             raise ConfigurationError(msg)
 
         dag_kwargs["dag_id"] = config.dag_id
-        if "start_date" not in dag_kwargs:
-            dag_kwargs["start_date"] = DEFAULT_START_DATE
-        elif isinstance(dag_kwargs["start_date"], str):
-            try:
-                parsed = datetime.fromisoformat(dag_kwargs["start_date"])
-            except ValueError as e:
-                msg = f"Invalid start_date format: {dag_kwargs['start_date']!r}"
-                raise ConfigurationError(msg) from e
-            if parsed.tzinfo is None:
-                parsed = parsed.replace(tzinfo=timezone.utc)
-            dag_kwargs["start_date"] = parsed
+        self._ensure_start_date(dag_kwargs)
         if "catchup" not in dag_kwargs:
             dag_kwargs["catchup"] = False
 
@@ -220,6 +239,8 @@ class Builder:
             for step_name, step_config in config.steps.items():
                 for dep_name in step_config.depends_on:
                     rendered[dep_name] >> rendered[step_name]
+                if step_config.trigger_rule is not None:
+                    self._apply_trigger_rule(rendered[step_name], step_config.trigger_rule)
 
         return dag
 
@@ -449,6 +470,22 @@ class Builder:
                 "blueprint_step_config": "yaml",
                 "blueprint_step_code": "py",
             }
+
+    def _apply_trigger_rule(self, rendered: TaskOrGroup, trigger_rule: str) -> None:
+        """Apply a trigger rule to the entry points of a rendered step.
+
+        For a single BaseOperator, sets trigger_rule directly.
+        For a TaskGroup, sets trigger_rule only on root tasks (tasks with no
+        internal upstream dependencies) so that internal group wiring is preserved.
+        """
+        from airflow.models import BaseOperator
+        from airflow.utils.task_group import TaskGroup
+
+        if isinstance(rendered, BaseOperator):
+            rendered.trigger_rule = trigger_rule
+        elif isinstance(rendered, TaskGroup):
+            for task in rendered.get_roots():
+                task.trigger_rule = trigger_rule
 
 
 def _check_duplicate_dag_id(dag_id: str, yaml_path: Path, dag_id_to_file: dict[str, Path]) -> None:

--- a/blueprint/cli.py
+++ b/blueprint/cli.py
@@ -210,10 +210,24 @@ def _get_registry(template_dir: str | None) -> BlueprintRegistry:
     return get_registry(template_dir)
 
 
+def _get_trigger_rule_values() -> list[str]:
+    """Get valid trigger rule values from the installed Airflow version."""
+    import contextlib
+    import io
+    import warnings
+
+    with warnings.catch_warnings(), contextlib.redirect_stderr(io.StringIO()):
+        warnings.simplefilter("ignore")
+        from airflow.utils.trigger_rule import TriggerRule
+
+    return sorted(str(r.value) for r in TriggerRule)
+
+
 def _build_version_schema(
     blueprint_name: str,
     version: int,
     raw_schema: dict,
+    trigger_rule_values: list[str],
 ) -> dict:
     """Build a schema variant for a single version of a blueprint."""
     schema_data = copy.deepcopy(raw_schema)
@@ -230,6 +244,17 @@ def _build_version_schema(
         "type": "integer",
         "const": version,
         "description": "The blueprint version",
+    }
+    schema_data["properties"]["depends_on"] = {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Steps that must complete before this step runs",
+        "default": [],
+    }
+    schema_data["properties"]["trigger_rule"] = {
+        "type": "string",
+        "enum": trigger_rule_values,
+        "description": "Trigger rule for this step (default: all_success)",
     }
 
     if "required" not in schema_data:
@@ -306,11 +331,13 @@ def schema(
             console.print(f"[red]Error:[/red] {e}")
             sys.exit(1)
 
+        trigger_rule_values = _get_trigger_rule_values()
         variants = [
             _build_version_schema(
                 blueprint_name,
                 vi["version"],
                 vi["schema"],
+                trigger_rule_values,
             )
             for vi in versions_info
         ]

--- a/blueprint/loaders.py
+++ b/blueprint/loaders.py
@@ -49,6 +49,24 @@ class _ContextProxy:
         return True
 
 
+class _StubVarAccessor:
+    """Stub Variable accessor for use outside Airflow (e.g. lint).
+
+    ``var.get(key, default)`` always returns the default.
+    ``var.value.key`` returns a placeholder string.
+    """
+
+    @property
+    def value(self) -> "_StubVarAccessor":
+        return self
+
+    def __getattr__(self, name: str) -> str:
+        return f"<{name}>"
+
+    def get(self, key: str, default: str | None = None) -> str | None:  # noqa: ARG002
+        return default
+
+
 def render_yaml_template(
     path: Path,
     context: dict[str, Any] | None = None,
@@ -75,9 +93,15 @@ def render_yaml_template(
 
     if has_jinja:
         try:
+            import os
+
             import jinja2
 
-            template_context: dict[str, Any] = {"context": _ContextProxy()}
+            template_context: dict[str, Any] = {
+                "context": _ContextProxy(),
+                "env": os.environ,
+                "var": _StubVarAccessor(),
+            }
             if use_airflow_context:
                 template_context.update(_get_airflow_context())
             if context:

--- a/examples/advanced/dags/satellite_telemetry.dag.yaml
+++ b/examples/advanced/dags/satellite_telemetry.dag.yaml
@@ -25,5 +25,6 @@ steps:
   transmit_results:
     blueprint: transmit
     depends_on: [analyze_signals]
+    trigger_rule: all_done
     destination: "{{ var.get('ground_station', 'DSN-Goldstone') }}"
     protocol: tcp

--- a/tests/integration/project/dags/versioned.dag.yaml
+++ b/tests/integration/project/dags/versioned.dag.yaml
@@ -28,5 +28,6 @@ steps:
   load_warehouse:
     blueprint: load
     depends_on: [transform]
+    trigger_rule: one_success
     target_table: analytics.customer_360
     mode: overwrite

--- a/tests/integration/test_dag_structure.py
+++ b/tests/integration/test_dag_structure.py
@@ -145,6 +145,14 @@ class TestVersionedETL:
                 f"Task {task_id} retries={task.get('retries')}, expected 3 (critical tier)"
             )
 
+    def test_load_warehouse_trigger_rule(self, api_client: AirflowAPI):
+        tasks = self._get_tasks(api_client)
+        assert tasks["load_warehouse"]["trigger_rule"] == "one_success"
+
+    def test_default_trigger_rule(self, api_client: AirflowAPI):
+        tasks = self._get_tasks(api_client)
+        assert tasks["transform.dedupe"]["trigger_rule"] == "all_success"
+
 
 class TestExplicitNaming:
     """Verify the explicit_naming DAG using blueprints with explicit name/version attrs.

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -94,6 +94,27 @@ class Nested(Blueprint[NestedConfig]):
         return outer
 
 
+class ChainedConfig(BaseModel):
+    operations: list[str] = Field(default_factory=lambda: ["first", "second"])
+
+
+class Chained(Blueprint[ChainedConfig]):
+    """Blueprint with internally chained tasks for trigger_rule testing."""
+
+    def render(self, config: ChainedConfig) -> TaskOrGroup:
+        from airflow.operators.bash import BashOperator
+        from airflow.utils.task_group import TaskGroup
+
+        with TaskGroup(group_id=self.step_id) as group:
+            prev = None
+            for op in config.operations:
+                t = BashOperator(task_id=op, bash_command=f"echo '{op}'")
+                if prev:
+                    prev >> t
+                prev = t
+        return group
+
+
 # --- Fixtures ---
 
 
@@ -104,11 +125,13 @@ def test_registry():
         "extract": {1: Extract, 2: ExtractV2},
         "load": {1: Load},
         "nested": {1: Nested},
+        "chained": {1: Chained},
     }
     reg._blueprint_locations = {
         "extract": {1: "test.py", 2: "test.py"},
         "load": {1: "test.py"},
         "nested": {1: "test.py"},
+        "chained": {1: "test.py"},
     }
     reg._discovered = True
     return reg
@@ -139,6 +162,21 @@ class TestStepConfig:
         step = StepConfig(blueprint="extract", version=2, sources=["a", "b"])
         assert step.version == 2
         assert step.get_blueprint_config() == {"sources": ["a", "b"]}
+
+    def test_step_with_trigger_rule(self):
+        step = StepConfig(blueprint="load", trigger_rule="one_success", target_table="out")
+        assert step.trigger_rule == "one_success"
+        assert "trigger_rule" not in step.get_blueprint_config()
+
+    def test_step_trigger_rule_default_none(self):
+        step = StepConfig(blueprint="load", target_table="out")
+        assert step.trigger_rule is None
+
+    def test_step_invalid_trigger_rule(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="Invalid trigger rule"):
+            StepConfig(blueprint="load", trigger_rule="bogus", target_table="out")
 
 
 # --- DAGConfig tests ---
@@ -389,6 +427,68 @@ class TestBuilder:
             assert "blueprint_step_config" in task.template_fields
             assert "blueprint_step_code" in task.template_fields
 
+    def test_trigger_rule_single_task(self, builder):
+        config = DAGConfig(
+            dag_id="tr_single",
+            steps={
+                "my_extract": StepConfig(blueprint="extract", version=1, source_table="raw.data"),
+                "my_load": StepConfig(
+                    blueprint="load",
+                    depends_on=["my_extract"],
+                    trigger_rule="one_success",
+                    target_table="out",
+                ),
+            },
+        )
+        dag = builder.build(config)
+        task = dag.task_dict["my_load"]
+        assert str(task.trigger_rule) == "one_success"
+
+    def test_trigger_rule_task_group_root_only(self, builder):
+        config = DAGConfig(
+            dag_id="tr_group",
+            steps={
+                "my_load": StepConfig(blueprint="load", target_table="out"),
+                "my_chained": StepConfig(
+                    blueprint="chained",
+                    depends_on=["my_load"],
+                    trigger_rule="all_done",
+                    operations=["first", "second"],
+                ),
+            },
+        )
+        dag = builder.build(config)
+        first = dag.task_dict["my_chained.first"]
+        second = dag.task_dict["my_chained.second"]
+        assert str(first.trigger_rule) == "all_done"
+        assert str(second.trigger_rule) == "all_success"
+
+    def test_trigger_rule_none_preserves_default(self, builder):
+        config = DAGConfig(
+            dag_id="tr_default",
+            steps={
+                "my_load": StepConfig(blueprint="load", target_table="out"),
+            },
+        )
+        dag = builder.build(config)
+        task = dag.task_dict["my_load"]
+        assert str(task.trigger_rule) == "all_success"
+
+    def test_trigger_rule_without_depends_on(self, builder):
+        config = DAGConfig(
+            dag_id="tr_no_deps",
+            steps={
+                "my_load": StepConfig(
+                    blueprint="load",
+                    trigger_rule="always",
+                    target_table="out",
+                ),
+            },
+        )
+        dag = builder.build(config)
+        task = dag.task_dict["my_load"]
+        assert str(task.trigger_rule) == "always"
+
 
 class TestBuilderDefaultDagArgs:
     def test_description_passed_to_dag(self, builder):
@@ -583,6 +683,27 @@ steps:
         upstream_ids = {t.task_id for t in load_task.upstream_list}
         upstream_group_ids = {t.group_id for t in load_task.upstream_list if hasattr(t, "group_id")}
         assert upstream_ids or upstream_group_ids, "my_load should depend on my_extract"
+
+    def test_build_from_yaml_with_trigger_rule(self, builder, tmp_path):
+        yaml_content = """
+dag_id: yaml_tr_dag
+steps:
+  my_extract:
+    blueprint: extract
+    version: 1
+    source_table: raw.data
+  my_load:
+    blueprint: load
+    depends_on: [my_extract]
+    trigger_rule: one_success
+    target_table: out
+"""
+        yaml_file = tmp_path / "tr.dag.yaml"
+        yaml_file.write_text(yaml_content)
+
+        dag = builder.build_from_yaml(yaml_file, render_template=False)
+        task = dag.task_dict["my_load"]
+        assert str(task.trigger_rule) == "one_success"
 
 
 class TestBuildFromYamlJinja:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -410,3 +410,52 @@ class MyCustomClass(Blueprint[MyCustomConfig]):
         schema = json.loads(result.output)
         assert schema["title"] == "weather_ingest"
         assert "MyCustomClass" not in result.output
+
+    def test_schema_includes_trigger_rule(self, tmp_path):
+        template_dir = tmp_path / "dags"
+        template_dir.mkdir()
+        (template_dir / "bp.py").write_text("""
+from pydantic import BaseModel
+from blueprint.core import Blueprint
+
+class StubConfig(BaseModel):
+    x: int = 1
+
+class Stub(Blueprint[StubConfig]):
+    def render(self, config):
+        pass
+""")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schema", "stub", "--template-dir", str(template_dir)])
+        assert result.exit_code == 0
+        schema = json.loads(result.output)
+        assert "trigger_rule" in schema["properties"]
+        tr_prop = schema["properties"]["trigger_rule"]
+        assert tr_prop["type"] == "string"
+        assert "enum" in tr_prop
+        assert "all_success" in tr_prop["enum"]
+        assert "one_success" in tr_prop["enum"]
+
+    def test_schema_includes_depends_on(self, tmp_path):
+        template_dir = tmp_path / "dags"
+        template_dir.mkdir()
+        (template_dir / "bp.py").write_text("""
+from pydantic import BaseModel
+from blueprint.core import Blueprint
+
+class StubConfig(BaseModel):
+    x: int = 1
+
+class Stub(Blueprint[StubConfig]):
+    def render(self, config):
+        pass
+""")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schema", "stub", "--template-dir", str(template_dir)])
+        assert result.exit_code == 0
+        schema = json.loads(result.output)
+        assert "depends_on" in schema["properties"]
+        dep_prop = schema["properties"]["depends_on"]
+        assert dep_prop["type"] == "array"


### PR DESCRIPTION
## Summary

- Adds `trigger_rule` as a reserved step-level field in DAG YAML, allowing users to control when a step runs relative to its upstream dependencies (e.g. `one_success`, `all_done`, `always`)
- Validates dynamically against the installed Airflow's `TriggerRule` enum — automatically correct for any version from 2.5.0 through 3.x
- For TaskGroups, applies trigger_rule only to root tasks, preserving internal group wiring
- Adds `trigger_rule` and `depends_on` to `blueprint schema` JSON output
- Fixes `blueprint lint` failing on templates using `{{ env.* }}` or `{{ var.get(...) }}` outside Airflow by always providing `env` and a stub `var` in the Jinja2 context

## Test plan

- [x] Unit tests: 245 passed (11 new covering StepConfig parsing, validation, single task, TaskGroup root-only, YAML round-trip, CLI schema)
- [x] Integration tests: 78 passed (2 new verifying trigger_rule via Airflow REST API against a live Astro instance)
- [x] Linting: `ruff check` and `ruff format` clean
- [x] `blueprint lint` passes on simple and advanced examples
- [x] `blueprint schema extract` includes `trigger_rule` enum from installed Airflow
- [x] Advanced example updated: `satellite_telemetry.dag.yaml` uses `trigger_rule: all_done`