### PR TITLE
Update /release skill to support patch releases

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -14,6 +14,7 @@ You are releasing version $ARGUMENTS of the `airflow-blueprint` package. Follow 
 
 - $ARGUMENTS must be a valid semver string (e.g. `0.3.0`, `1.0.0`). Reject pre-release suffixes unless the user explicitly asked for one.
 - Read `blueprint/__init__.py` and confirm the current `__version__` is older than $ARGUMENTS.
+- Determine whether this is a **patch release** (patch component > 0, e.g. `0.2.1`) or a **minor/major release** (patch component is 0, e.g. `0.3.0`, `1.0.0`).
 
 ## 2. Run local quality checks
 
@@ -25,7 +26,50 @@ Run all three in parallel:
 
 All must pass before continuing.
 
-## 3. Create a release branch and bump the version
+---
+
+## Patch release flow (e.g. 0.2.1, 1.3.2)
+
+Patch releases are made from a release branch off the previous tag, not from main. This allows bug fixes to be released without pulling in unreleased feature work on main.
+
+### 3p. Create a release branch from the previous tag
+
+Find the previous tag in the same minor series (e.g. for `0.2.1` use `v0.2.0`, for `0.2.2` use `v0.2.1`).
+
+- `git checkout -b release/v$ARGUMENTS <previous_tag>`
+
+### 4p. Cherry-pick bug fixes
+
+Ask the user which commits to include. Show them the commits on main since the previous tag to help them choose:
+
+- `git log <previous_tag>..main --oneline`
+
+Cherry-pick each selected commit onto the release branch:
+
+- `git cherry-pick <commit_sha>`
+
+If any cherry-pick has conflicts, stop and ask the user for guidance.
+
+### 5p. Bump the version, tag, and push
+
+- Edit `blueprint/__init__.py`: set `__version__ = "$ARGUMENTS"`
+- `git add blueprint/__init__.py`
+- `git commit -m "Release v$ARGUMENTS"`
+- `git push -u origin release/v$ARGUMENTS`
+- `git tag v$ARGUMENTS`
+- `git push origin v$ARGUMENTS`
+
+This triggers the release workflow which builds and publishes to PyPI and TestPyPI.
+
+### 6p. Continue to step 8.
+
+---
+
+## Minor/major release flow (e.g. 0.3.0, 1.0.0)
+
+Minor and major releases are made from main via a PR.
+
+### 3. Create a release branch and bump the version
 
 - `git checkout -b release/v$ARGUMENTS`
 - Edit `blueprint/__init__.py`: set `__version__ = "$ARGUMENTS"`
@@ -33,24 +77,24 @@ All must pass before continuing.
 - `git commit -m "Release v$ARGUMENTS"`
 - `git push -u origin release/v$ARGUMENTS`
 
-## 4. Open a PR
+### 4. Open a PR
 
 ```
 gh pr create --title "Release v$ARGUMENTS" --body "Bump version to $ARGUMENTS."
 ```
 
-## 5. Wait for CI to pass
+### 5. Wait for CI to pass
 
 - `gh pr checks <PR_NUMBER> --watch`
 - All checks must pass. If any fail, investigate and fix before continuing.
 
-## 6. Merge the PR
+### 6. Merge the PR
 
 ```
 gh pr merge <PR_NUMBER> --squash
 ```
 
-## 7. Tag the merge commit on main
+### 7. Tag the merge commit on main
 
 - `git checkout main && git pull`
 - `git tag v$ARGUMENTS`
@@ -58,13 +102,17 @@ gh pr merge <PR_NUMBER> --squash
 
 This triggers the release workflow which builds and publishes to PyPI and TestPyPI.
 
-## 8. Wait for the release workflow to pass
+---
+
+## Common steps (both flows)
+
+### 8. Wait for the release workflow to pass
 
 - Find the workflow run: `gh run list --branch v$ARGUMENTS --limit 1`
 - Watch it: `gh run watch <RUN_ID>`
 - Confirm that the **Publish to PyPI** and **Publish to TestPyPI** jobs both succeed.
 
-## 9. Draft release notes
+### 9. Draft release notes
 
 Before creating the release, analyze all commits since the last tag to draft release notes. Use `git log <previous_tag>..v$ARGUMENTS --oneline` and read the relevant diffs to understand each change.
 
@@ -95,13 +143,13 @@ Guidelines:
 - Omit purely internal changes (CI, test infra, docs-only) from the top-level notes unless they are significant to users.
 - For breaking changes, always include a before/after code example showing the migration path.
 
-## 10. Create the GitHub release
+### 10. Create the GitHub release
 
 ```
 gh release create v$ARGUMENTS --title "v$ARGUMENTS" --notes "<drafted notes>"
 ```
 
-## 11. Clean up
+### 11. Clean up
 
 - Delete the local release branch: `git branch -d release/v$ARGUMENTS`
 - Report the release URL and a summary to the user.


### PR DESCRIPTION
## Summary
- Adds a separate patch release flow that branches from the previous tag and cherry-picks selected bug fixes
- Minor/major releases continue to go through main via PR
- Both flows converge on the same steps for workflow monitoring, release notes, and cleanup