### PR TITLE
Fix invalid JSON when piping blueprint schema output

### DIFF
--- a/blueprint/cli.py
+++ b/blueprint/cli.py
@@ -358,9 +358,11 @@ def schema(
     if output:
         Path(output).write_text(json_output)
         console.print(f"[green]Schema written to {output}[/green]")
-    else:
+    elif sys.stdout.isatty():
         syntax = Syntax(json_output, "json", theme="monokai")
         console.print(syntax)
+    else:
+        click.echo(json_output)
 
 
 def _select_blueprint(blueprints: list[dict[str, Any]]) -> dict[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -459,3 +459,71 @@ class Stub(Blueprint[StubConfig]):
         assert "depends_on" in schema["properties"]
         dep_prop = schema["properties"]["depends_on"]
         assert dep_prop["type"] == "array"
+
+    def test_schema_piped_output_is_raw_json(self, tmp_path):
+        """When stdout is not a TTY, schema must emit raw JSON parseable by json.loads.
+
+        Regression: previously rendered via Rich Syntax which wrapped/padded lines and
+        dropped commas at line boundaries, producing output that looked like JSON but
+        failed to parse.
+        """
+        template_dir = tmp_path / "dags"
+        template_dir.mkdir()
+        (template_dir / "bp.py").write_text("""
+from pydantic import BaseModel, Field
+from blueprint.core import Blueprint
+
+class WideConfig(BaseModel):
+    a_long_parameter_name_that_would_wrap: str = Field(description="x" * 80)
+    another_long_parameter_name: str = Field(description="y" * 80)
+    yet_another_one: int = 1
+
+class Wide(Blueprint[WideConfig]):
+    def render(self, config):
+        pass
+""")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schema", "wide", "--template-dir", str(template_dir)])
+        assert result.exit_code == 0
+
+        schema = json.loads(result.output)
+        assert schema["title"] == "wide"
+        assert "a_long_parameter_name_that_would_wrap" in schema["properties"]
+
+        for line in result.output.splitlines():
+            assert line == line.rstrip(), f"line has trailing whitespace: {line!r}"
+        assert "\x1b[" not in result.output
+
+    def test_schema_output_file_writes_valid_json(self, tmp_path):
+        """The --output flag writes raw JSON to the file regardless of TTY state."""
+        template_dir = tmp_path / "dags"
+        template_dir.mkdir()
+        (template_dir / "bp.py").write_text("""
+from pydantic import BaseModel
+from blueprint.core import Blueprint
+
+class OutConfig(BaseModel):
+    x: int = 1
+
+class Out(Blueprint[OutConfig]):
+    def render(self, config):
+        pass
+""")
+
+        out_file = tmp_path / "out.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "schema",
+                "out",
+                "--template-dir",
+                str(template_dir),
+                "--output",
+                str(out_file),
+            ],
+        )
+        assert result.exit_code == 0
+        schema = json.loads(out_file.read_text())
+        assert schema["title"] == "out"


### PR DESCRIPTION
## Summary
- `blueprint schema NAME > file.json` previously captured Rich's rendered output (wrapped lines, padding, dropped commas at line boundaries), producing a file that looked like JSON but failed `json.loads`. The Astro IDE silently dropped these invalid schemas, so the symptom was "templates don't show up in the IDE library" with no error anywhere.
- Now emit raw JSON via `click.echo` when stdout is not a TTY; keep Rich `Syntax` highlighting for interactive use.

## Test plan
- [x] `uv run pytest tests/test_cli.py -v` (25 passed)
- [x] `uv run ruff check blueprint/ tests/`
- [x] Added `test_schema_piped_output_is_raw_json` — uses long parameter names that previously triggered Rich line-wrapping; asserts `json.loads(output)` succeeds, no trailing whitespace, no ANSI escapes
- [x] Added `test_schema_output_file_writes_valid_json` — confirms `--output FILE` writes parseable JSON