### PR TITLE
Restrict Blueprint config types to disallow multi-type unions

### DIFF
--- a/blueprint/core.py
+++ b/blueprint/core.py
@@ -76,12 +76,16 @@ def _is_yaml_compatible(annotation: Any, seen: set[int] | None = None) -> str | 
     args = get_args(annotation)
 
     if origin is Union or isinstance(annotation, types.UnionType):
-        for arg in args or get_args(annotation):
-            if arg is type(None):
-                continue
-            error = _is_yaml_compatible(arg, seen)
-            if error:
-                return error
+        all_args = args or get_args(annotation)
+        non_none_args = [a for a in all_args if a is not type(None)]
+        if len(non_none_args) > 1:
+            names = ", ".join(getattr(a, "__name__", repr(a)) for a in non_none_args)
+            return (
+                f"union types are not allowed (got {names}); "
+                f"use a single type (Optional[X] / X | None is allowed)"
+            )
+        if non_none_args:
+            return _is_yaml_compatible(non_none_args[0], seen)
         return None
 
     if origin is Literal:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,7 +5,7 @@ import enum
 import uuid
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Optional, Union
 
 import pytest
 from pydantic import BaseModel, Field
@@ -363,15 +363,88 @@ class TestYamlTypeValidation:
 
         assert LitMixedBp.get_config_type() is LitMixedConfig
 
-    def test_valid_union(self):
+    def test_invalid_union_two_types(self):
         class UnionConfig(BaseModel):
             value: str | int
 
-        class UnionBp(Blueprint[UnionConfig]):
+        with pytest.raises(TypeError, match="non-YAML-compatible"):
+
+            class UnionBp(Blueprint[UnionConfig]):
+                def render(self, config):
+                    pass
+
+    def test_invalid_typing_union(self):
+        class UnionConfig(BaseModel):
+            value: Union[str, int]  # noqa: UP007
+
+        with pytest.raises(TypeError, match="non-YAML-compatible"):
+
+            class UnionBp(Blueprint[UnionConfig]):
+                def render(self, config):
+                    pass
+
+    def test_invalid_union_three_types(self):
+        class UnionConfig(BaseModel):
+            value: str | int | bool
+
+        with pytest.raises(TypeError, match="non-YAML-compatible"):
+
+            class UnionBp(Blueprint[UnionConfig]):
+                def render(self, config):
+                    pass
+
+    def test_valid_optional_pipe(self):
+        class OptConfig(BaseModel):
+            value: str | None = None
+
+        class OptBp(Blueprint[OptConfig]):
             def render(self, config):
                 pass
 
-        assert UnionBp.get_config_type() is UnionConfig
+        assert OptBp.get_config_type() is OptConfig
+
+    def test_valid_optional_typing(self):
+        class OptConfig(BaseModel):
+            value: Optional[str] = None  # noqa: UP045
+
+        class OptBp(Blueprint[OptConfig]):
+            def render(self, config):
+                pass
+
+        assert OptBp.get_config_type() is OptConfig
+
+    def test_invalid_union_in_list(self):
+        class ListUnionConfig(BaseModel):
+            items: list[str | int]
+
+        with pytest.raises(TypeError, match="non-YAML-compatible"):
+
+            class ListUnionBp(Blueprint[ListUnionConfig]):
+                def render(self, config):
+                    pass
+
+    def test_invalid_union_in_dict_value(self):
+        class DictUnionConfig(BaseModel):
+            mapping: dict[str, str | int]
+
+        with pytest.raises(TypeError, match="non-YAML-compatible"):
+
+            class DictUnionBp(Blueprint[DictUnionConfig]):
+                def render(self, config):
+                    pass
+
+    def test_invalid_union_in_nested_model(self):
+        class Inner(BaseModel):
+            x: str | int
+
+        class OuterConfig(BaseModel):
+            inner: Inner
+
+        with pytest.raises(TypeError, match="non-YAML-compatible"):
+
+            class OuterBp(Blueprint[OuterConfig]):
+                def render(self, config):
+                    pass
 
     def test_invalid_enum(self):
         class Color(enum.Enum):
@@ -764,6 +837,16 @@ class TestBlueprintDagArgs:
         with pytest.raises(TypeError, match="non-YAML-compatible"):
 
             class BadDagArgs(BlueprintDagArgs[BadConfig]):
+                def render(self, _config):
+                    return {}
+
+    def test_dag_args_rejects_union(self):
+        class UnionConfig(BaseModel):
+            value: str | int
+
+        with pytest.raises(TypeError, match="non-YAML-compatible"):
+
+            class UnionDagArgs(BlueprintDagArgs[UnionConfig]):
                 def render(self, _config):
                     return {}
 


### PR DESCRIPTION
## Summary
- Config fields like `str | int` or `Union[A, B]` are no longer accepted on Blueprint or BlueprintDagArgs config models.
- Motivation: multi-type unions render as `anyOf` in JSON Schema (Astro IDE handles them poorly) and make YAML parsing ambiguous (e.g., `"1"` could resolve to `str` or `int`).
- `Optional[X]` / `X | None` is still allowed — the nullable-field pattern is common and unambiguous.
- The check lives in `_is_yaml_compatible` (`blueprint/core.py`) and already recurses into nested `BaseModel`s, list elements, and dict values, so the restriction propagates automatically.

## Test plan
- [x] `uv run pytest tests/ --ignore=tests/integration` — 255 passed
- [x] `uv run ruff check blueprint/ tests/` — clean
- [x] `uv run ty check blueprint/` — clean
- [x] Replaced `test_valid_union` with `test_invalid_union_two_types`; added 7 new tests covering `Union[...]`, three-type unions, both `Optional` forms (still pass), and unions inside `list` / `dict` / nested models
- [x] Added `test_dag_args_rejects_union` mirroring the existing DAG-args validation test
- [x] `uv run blueprint schema scan --template-dir examples/advanced --output /tmp/scan.json` — example blueprints still build and emit valid JSON