### PR TITLE
Support rendering blueprints inside hand-written Python DAGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,45 @@ steps:
 > **Note:** Parse-time Jinja2 filters and arithmetic on `context` values are not supported.
 > For complex expressions, use `{% raw %}{{ ds | some_filter }}{% endraw %}` instead.
 
+## Using Blueprints in Hand-Written Python DAGs
+
+Blueprints aren't tied to the YAML composition flow. If you already have a regular Python DAG and just want to drop in a blueprint-rendered step amongst your existing tasks, you can instantiate the Blueprint class directly and call `render()` inside a `with DAG(...)` block:
+
+```python
+# dags/hybrid_dag.py
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+from dags.etl_blueprints import Extract, ExtractConfig, Load, LoadConfig
+
+
+with DAG(
+    dag_id="hybrid_python_dag",
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+) as dag:
+    setup = BashOperator(task_id="setup", bash_command="echo 'setup'")
+
+    extract = Extract()
+    extract.step_id = "extract"
+    extract_group = extract.render(ExtractConfig(source_table="raw.events", batch_size=100))
+
+    load = Load()
+    load.step_id = "load"
+    load_task = load.render(LoadConfig(target_table="warehouse.events", mode="append"))
+
+    finalize = BashOperator(task_id="finalize", bash_command="echo 'done'")
+
+    setup >> extract_group >> load_task >> finalize
+```
+
+Set `step_id` on the instance (it determines the `task_id` / `group_id` the blueprint renders under), then call `render(config)` to get back a `BaseOperator` or `TaskGroup` you can wire into the rest of your DAG. This is useful for incrementally adopting blueprints in an existing Python-DAG codebase without rewriting everything in YAML.
+
+> **Why the `dags.` prefix?** Astro's runtime image puts `/usr/local/airflow` on `PYTHONPATH`, so `dags/` is importable as a namespace package. The prefixed form resolves identically in the live scheduler, in `astro deploy --parse`'s DagBag check, and in any `DagBag()`-based integrity test — no `sys.path` shim or conftest setup required. A flat `from etl_blueprints import …` would work in the scheduler but fail under bare `DagBag()` scans (including the default `astro deploy` parse gate), so prefer the prefixed form.
+
 ## Programmatic Building
 
 For advanced use cases, build DAGs programmatically:

--- a/blueprint/registry.py
+++ b/blueprint/registry.py
@@ -1,5 +1,6 @@
 """Global registry for Blueprint discovery and management with version tracking."""
 
+import ast
 import importlib.util
 import logging
 import os
@@ -17,6 +18,35 @@ from blueprint.errors import (
 )
 
 logger = logging.getLogger(__name__)
+
+_BLUEPRINT_BASE_NAMES = frozenset({"Blueprint", "BlueprintDagArgs"})
+
+
+def _defines_blueprint_subclass(py_file: Path) -> bool:
+    """Return True if the file's source defines a Blueprint or BlueprintDagArgs subclass.
+
+    Uses AST inspection rather than executing the file, so that Python DAG files and
+    other non-blueprint code in the search path are not run during discovery. Matches
+    bases written as `Blueprint`, `Blueprint[Config]`, `BlueprintDagArgs`, or
+    `BlueprintDagArgs[Config]`. Files that subclass via an alias (e.g. `import Blueprint
+    as B`) are not matched and should be opted-in via an explicit registry config.
+    """
+    try:
+        source = py_file.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    try:
+        tree = ast.parse(source, filename=str(py_file))
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for base in node.bases:
+            target = base.value if isinstance(base, ast.Subscript) else base
+            if isinstance(target, ast.Name) and target.id in _BLUEPRINT_BASE_NAMES:
+                return True
+    return False
 
 
 class BlueprintRegistry:
@@ -95,6 +125,8 @@ class BlueprintRegistry:
             if py_file.name.startswith("_"):
                 continue
             if py_file.resolve() in self._exclude_files:
+                continue
+            if not _defines_blueprint_subclass(py_file):
                 continue
 
             try:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -10,7 +10,7 @@ from blueprint.errors import (
     MultipleDagArgsError,
     NonContiguousVersionError,
 )
-from blueprint.registry import BlueprintRegistry
+from blueprint.registry import BlueprintRegistry, _defines_blueprint_subclass
 
 
 class SimpleConfig(BaseModel):
@@ -561,3 +561,115 @@ class MyDa(BlueprintDagArgs[DaConfig]):
         bp_names = [bp["name"] for bp in reg.list_blueprints()]
         assert "my_bp" in bp_names
         assert "my_da" not in bp_names
+
+
+class TestNonBlueprintFileFiltering:
+    """Verify that non-blueprint .py files in the search path are not executed.
+
+    The registry previously exec'd every .py file to find Blueprint subclasses.
+    That meant Python DAG files, utility modules, and any other code that
+    happened to live alongside blueprint definitions had their top-level code
+    run as a side effect of discovery (e.g. creating DAG objects, opening
+    network sockets, etc.). The AST-based pre-filter avoids that.
+    """
+
+    def test_defines_blueprint_subclass_recognizes_subscripted_base(self, tmp_path):
+        py_file = tmp_path / "bp.py"
+        py_file.write_text(
+            "from blueprint.core import Blueprint\nclass X(Blueprint[object]):\n    pass\n"
+        )
+        assert _defines_blueprint_subclass(py_file) is True
+
+    def test_defines_blueprint_subclass_recognizes_bare_base(self, tmp_path):
+        py_file = tmp_path / "bp.py"
+        py_file.write_text("from blueprint.core import Blueprint\nclass X(Blueprint):\n    pass\n")
+        assert _defines_blueprint_subclass(py_file) is True
+
+    def test_defines_blueprint_subclass_recognizes_blueprint_dag_args(self, tmp_path):
+        py_file = tmp_path / "da.py"
+        py_file.write_text(
+            "from blueprint.core import BlueprintDagArgs\n"
+            "class X(BlueprintDagArgs[object]):\n"
+            "    pass\n"
+        )
+        assert _defines_blueprint_subclass(py_file) is True
+
+    def test_defines_blueprint_subclass_rejects_plain_module(self, tmp_path):
+        py_file = tmp_path / "utils.py"
+        py_file.write_text("def helper():\n    return 42\n")
+        assert _defines_blueprint_subclass(py_file) is False
+
+    def test_defines_blueprint_subclass_rejects_unrelated_class(self, tmp_path):
+        py_file = tmp_path / "other.py"
+        py_file.write_text("class Foo:\n    pass\nclass Bar(Foo):\n    pass\n")
+        assert _defines_blueprint_subclass(py_file) is False
+
+    def test_defines_blueprint_subclass_rejects_syntax_error(self, tmp_path):
+        py_file = tmp_path / "broken.py"
+        py_file.write_text("def (\n")
+        assert _defines_blueprint_subclass(py_file) is False
+
+    def test_defines_blueprint_subclass_misses_aliased_import(self, tmp_path):
+        """Documented limitation: aliased imports aren't matched by the AST scan."""
+        py_file = tmp_path / "aliased.py"
+        py_file.write_text(
+            "from blueprint.core import Blueprint as B\nclass X(B[object]):\n    pass\n"
+        )
+        assert _defines_blueprint_subclass(py_file) is False
+
+    def test_non_blueprint_file_is_not_executed(self, tmp_path):
+        """A side-effecting non-blueprint file is left alone during discovery.
+
+        If the registry exec'd this file, the sentinel marker file would appear.
+        The blueprint registry must not run user Python that does not declare
+        a Blueprint subclass.
+        """
+        template_dir = tmp_path / "dags"
+        template_dir.mkdir()
+
+        sentinel = tmp_path / "side_effect_ran"
+        side_effect_file = template_dir / "hybrid_dag.py"
+        side_effect_file.write_text(
+            f"from pathlib import Path\nPath({str(sentinel)!r}).write_text('triggered')\n"
+        )
+
+        # Provide a real blueprint so discovery has something to find.
+        (template_dir / "blueprints.py").write_text(
+            "from pydantic import BaseModel\n"
+            "from blueprint.core import Blueprint\n"
+            "class Cfg(BaseModel):\n"
+            "    x: str = 'a'\n"
+            "class Real(Blueprint[Cfg]):\n"
+            "    def render(self, config):\n"
+            "        pass\n"
+        )
+
+        reg = BlueprintRegistry(template_dirs=[template_dir])
+        reg.discover(force=True)
+
+        bp_names = [bp["name"] for bp in reg.list_blueprints()]
+        assert "real" in bp_names, "Blueprint discovery should still find real blueprints"
+        assert not sentinel.exists(), (
+            "Registry exec'd a non-blueprint .py file — the AST pre-filter is not active"
+        )
+
+    def test_blueprint_file_is_still_executed(self, tmp_path):
+        """Files that declare a Blueprint subclass must still be imported and registered."""
+        template_dir = tmp_path / "dags"
+        template_dir.mkdir()
+
+        (template_dir / "etl.py").write_text(
+            "from pydantic import BaseModel\n"
+            "from blueprint.core import Blueprint\n"
+            "class Cfg(BaseModel):\n"
+            "    x: str = 'a'\n"
+            "class Etl(Blueprint[Cfg]):\n"
+            "    def render(self, config):\n"
+            "        pass\n"
+        )
+
+        reg = BlueprintRegistry(template_dirs=[template_dir])
+        reg.discover(force=True)
+
+        bp_names = [bp["name"] for bp in reg.list_blueprints()]
+        assert "etl" in bp_names


### PR DESCRIPTION
## Summary

Blueprints can be instantiated and rendered directly inside a `with DAG(...)` block alongside regular tasks, so teams with existing Python DAGs can adopt blueprints incrementally without rewriting everything in YAML.

- **README**: new "Using Blueprints in Hand-Written Python DAGs" section. The example uses `from dags.<module> import …` (the prefixed form) because Astro's runtime image sets `PYTHONPATH=/usr/local/airflow` ([astro-runtime image/Dockerfile:19](https://github.com/astronomer/astro-runtime/blob/main/image/Dockerfile#L19)) — so the import resolves identically in the live scheduler, in `astro deploy --parse`'s DagBag gate, and in any DagBag-based integrity test, with no `sys.path` shim or conftest setup required.
- **Registry**: skip non-blueprint files during discovery. Previously every `.py` file in the search path was exec'd to find Blueprint subclasses, which ran top-level side effects (DAG creation, network calls, etc.) in user files that just happened to live next to blueprint definitions. Now uses `ast.parse` to detect `Blueprint` / `BlueprintDagArgs` subclass definitions without executing the file, and only exec's files that actually declare one. Avoids `AirflowDagDuplicatedIdException` when a hand-written Python DAG sits in the same `dags/` folder as the blueprints it imports.
- **Tests**: 9 new tests covering the AST detection (subscripted bases, bare bases, `BlueprintDagArgs` variant, plain modules, unrelated classes, syntax errors, documented aliased-import miss) and a regression guard that asserts a side-effecting non-blueprint `.py` file in the search path is NOT executed during discovery.

## Test plan

- [x] `uv run ruff check blueprint/ tests/`
- [x] `uv run pytest tests/ --ignore=tests/integration` (265 passed)
- [x] `uv run pytest tests/test_registry.py::TestNonBlueprintFileFiltering` (9 passed)