### PR TITLE
Harden CI workflows against supply-chain and prompt-injection risks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Keep pinned GitHub Action SHAs up to date. Without this, SHA pinning means
+  # we stop receiving upstream security/bug fixes silently. Dependabot opens a
+  # PR with the new SHA + release notes whenever any pinned action publishes.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,12 @@ on:
 
 jobs:
   claude-review:
-    # Safety: Only run for trusted contributors (forks have read-only tokens)
+    # Safety: Only run for trusted contributors. COLLABORATOR is intentionally
+    # excluded — a single rogue/compromised collaborator could otherwise exfiltrate
+    # CLAUDE_CODE_OAUTH_TOKEN via the PR's pyproject.toml/uv.lock.
     if: |
       github.event.pull_request.author_association == 'OWNER' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.author_association == 'COLLABORATOR'
+      github.event.pull_request.author_association == 'MEMBER'
 
     runs-on: ubuntu-latest
     permissions:
@@ -26,22 +27,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@4481e6d3c7bbb88db2a928ca3444c536f589c7c1 # v1.0.131
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
-
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          # Prompt for automated review (no @claude mention needed)
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
@@ -54,15 +52,14 @@ jobs:
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true
 
-          # Allow Claude to run validation and testing commands
-          allowed_tools: |
-            Bash(uv run ruff check blueprint/ tests/),
-            Bash(uv run ruff format --check blueprint/ tests/),
-            Bash(uv run ty check blueprint/),
-            Bash(uv run pytest tests/ -v),
-            Bash(uv run blueprint --help),
-            Bash(cd examples/simple && uv run blueprint list),
-            Bash(cd examples/advanced && uv run blueprint list)
+          # Security: this workflow runs against attacker-controllable PR code.
+          # We do NOT grant any Bash/test-execution tools — `uv run` would install
+          # from the PR's pyproject.toml/uv.lock and could exfiltrate the OAuth
+          # token via a malicious build backend. CI runs the same checks already.
+          # We also explicitly disallow the action's default write-capable tools
+          # (Edit/Write/git Bash) so an injected prompt cannot modify the PR.
+          # Pass `--model` via claude_args to change the model.
+          claude_args: --disallowedTools "Edit,MultiEdit,Write,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rm:*)"
 
           # Optional: Skip review for certain conditions
           # if: |

--- a/.github/workflows/claude-issue-review.yml
+++ b/.github/workflows/claude-issue-review.yml
@@ -21,20 +21,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Review New Issue
         id: claude-issue-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@4481e6d3c7bbb88db2a928ca3444c536f589c7c1 # v1.0.131
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Use Claude Opus for more thorough analysis
-          # model: "claude-opus-4-1-20250805"
+          # Pass `--model "claude-opus-4-1-20250805"` (etc.) in claude_args below to change the model.
 
-          direct_prompt: |
+          prompt: |
             Please review this new issue and provide helpful feedback:
 
             1. **Categorization**: Suggest appropriate labels based on content:
@@ -70,11 +69,7 @@ jobs:
             Be constructive, helpful, and welcoming in your response.
 
           # Allow limited tools for checking project context
-          allowed_tools: |
-            Bash(uv run blueprint --help),
-            Bash(cd examples/simple && uv run blueprint list),
-            Bash(cd examples/advanced && uv run blueprint list),
-            Bash(ls examples/simple/dags/ examples/advanced/dags/)
+          claude_args: --allowedTools "Bash(uv run blueprint --help),Bash(cd examples/simple && uv run blueprint list),Bash(cd examples/advanced && uv run blueprint list),Bash(ls examples/simple/dags/ examples/advanced/dags/)"
 
           # Use sticky comment so Claude updates the same comment if issue is edited
           use_sticky_comment: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,28 @@ on:
 
 jobs:
   claude:
+    # Safety: Only run for trusted contributors to prevent abuse and prompt injection
+    # from arbitrary commenters. Mirrors the gate used in claude-code-review.yml.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+          (github.event.comment.author_association == 'OWNER' ||
+           github.event.comment.author_association == 'MEMBER' ||
+           github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+          (github.event.comment.author_association == 'OWNER' ||
+           github.event.comment.author_association == 'MEMBER' ||
+           github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+          (github.event.review.author_association == 'OWNER' ||
+           github.event.review.author_association == 'MEMBER' ||
+           github.event.review.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'issues' &&
+          (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+          (github.event.issue.author_association == 'OWNER' ||
+           github.event.issue.author_association == 'MEMBER' ||
+           github.event.issue.author_association == 'COLLABORATOR'))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,13 +43,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@4481e6d3c7bbb88db2a928ca3444c536f589c7c1 # v1.0.131
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -40,27 +57,12 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
-
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
 
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
 
-          # Allow Claude to run project-specific commands
-          allowed_tools: |
-            Bash(uv sync:*),
-            Bash(uv run blueprint:*),
-            Bash(uv run pytest:*),
-            Bash(uv run ruff check:*),
-            Bash(uv run ruff format:*),
-            Bash(uv run ty check:*),
-            Bash(uv build),
-            Bash(cd examples/simple && uv run blueprint:*),
-            Bash(cd examples/advanced && uv run blueprint:*)
-
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
+          # Allow Claude to run project-specific commands.
+          # Pass `--model "claude-opus-4-1-20250805"` (etc.) in claude_args to change the model.
+          claude_args: --allowedTools "Bash(uv sync:*),Bash(uv run blueprint:*),Bash(uv run pytest:*),Bash(uv run ruff check:*),Bash(uv run ruff format:*),Bash(uv run ty check:*),Bash(uv build),Bash(cd examples/simple && uv run blueprint:*),Bash(cd examples/advanced && uv run blueprint:*)"

--- a/.github/workflows/lint-reusable.yml
+++ b/.github/workflows/lint-reusable.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, lint]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -38,7 +38,7 @@ jobs:
         run: uv build
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-package-distributions
           path: dist/
@@ -56,13 +56,13 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   publish-to-testpypi:
     name: Publish to TestPyPI
@@ -76,12 +76,12 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ${{ inputs.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
## Summary

Maintenance pass on `.github/workflows/`. Three categories of change: contributor-gate tightening on the Claude workflows, migration off deprecated `anthropics/claude-code-action` inputs, and pinning every third-party action to an immutable commit SHA.

### Contributor gates

- `claude.yml`: `@claude` mention triggers now require `author_association` of `OWNER`/`MEMBER`/`COLLABORATOR`, matching `claude-code-review.yml`'s existing gate.
- `claude-code-review.yml`: `COLLABORATOR` removed from the gate (now `OWNER`/`MEMBER` only).

### Tool scoping in Claude workflows

- `claude-code-review.yml`: removed the bash `allowed_tools` block (CI runs the same checks). Added `disallowed_tools` covering `Edit`/`MultiEdit`/`Write` and the write-capable git Bash subcommands.
- `claude.yml` and `claude-issue-review.yml`: bash tool lists preserved, just re-expressed in the new syntax (below).

### `anthropics/claude-code-action` input migration

`direct_prompt` and `allowed_tools`/`disallowed_tools` are no longer recognized in `v1.0.131`. Migrated all three workflows:

- `direct_prompt:` → `prompt:`
- `allowed_tools: \| ...` → `claude_args: --allowedTools "..."`
- `disallowed_tools: \| ...` → `claude_args: --disallowedTools "..."`

### Actions pinned to commit SHAs

Every `uses:` reference now points at a full commit SHA with a `# vX.Y.Z` comment:

| Action | Was | Now |
|---|---|---|
| `anthropics/claude-code-action` | `@beta` | `v1.0.131` |
| `actions/checkout` | `@v4` | `v6.0.2` |
| `astral-sh/setup-uv` | `@v4` | `v8.1.0` |
| `actions/upload-artifact` | `@v4` | `v7.0.1` |
| `actions/download-artifact` | `@v4` | `v8.0.1` |
| `pypa/gh-action-pypi-publish` | `@release/v1` | `v1.14.0` |

Release notes for each major-version jump were checked against this repo's usage; none of the breaking changes apply.

### Dependabot

Added `.github/dependabot.yml` with a weekly `github-actions` update grouped into a single PR, so pinned SHAs don't go stale.

## Test plan

- [ ] CI passes against the new `checkout` and `setup-uv` SHAs
- [ ] `grep -rE 'uses: [^@]+@(v[0-9]+($|[^0-9])|beta|main|master|release/v1)' .github/workflows/` returns nothing
- [ ] First Dependabot run opens against `github-actions` after merge
- [ ] Next `@claude` mention from a maintainer behaves as expected with the new `claude_args` syntax
- [ ] Next PR's auto-review posts a comment and does not invoke shell tools