### PR TITLE
Add programmatic DAG-building example

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,8 @@ config = DAGConfig(
 dag = Builder().build(config)
 ```
 
+`DAGConfig` accepts the same fields you would write in YAML -- `dag_id`, `steps`, and any DAG-arg fields your `BlueprintDagArgs` consumes -- so this is handy when the set of DAGs is data-driven (one per region, tenant, or, in the example below, satellite). See [`examples/advanced/dags/programmatic_dags.py`](examples/advanced/dags/programmatic_dags.py), which builds one DAG per satellite in a loop and registers each in `globals()` for Airflow to discover.
+
 ## Post-Processing DAGs
 
 The `on_dag_built` callback lets you modify each DAG after it's built from YAML. It receives the DAG and the path to the source YAML file:

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ tilt up
 
 ## [Advanced](advanced/)
 
-Space-themed example demonstrating many Blueprint features: versioning, runtime params, custom DAG args, Jinja2 templating, `on_dag_built` callbacks, and more.
+Space-themed example demonstrating many Blueprint features: versioning, runtime params, custom DAG args, Jinja2 templating, `on_dag_built` callbacks, programmatic DAG building with the `Builder` API, and more.
 
 ```bash
 cd examples/advanced/airflow3

--- a/examples/advanced/README.md
+++ b/examples/advanced/README.md
@@ -1,6 +1,6 @@
 # Advanced Example
 
-Space-themed example demonstrating many Blueprint features across two DAGs and five blueprints.
+Space-themed example demonstrating many Blueprint features across two YAML DAGs, a set of programmatically-built DAGs, and five blueprints.
 
 ## Quick Start
 
@@ -45,3 +45,10 @@ Custom `BlueprintDagArgs` subclass that converts a `priority` field into a DAG t
 ### Loader (`dags/loader.py`)
 
 `build_all()` with `on_dag_built` callback and `template_context`.
+
+### Programmatic Building (`dags/programmatic_dags.py`)
+
+Builds DAGs in a loop with the `Builder` API instead of YAML. One telemetry DAG
+is generated per satellite from a plain Python list (`telemetry_sat_001`,
+`telemetry_sat_002`, `telemetry_sat_003`), reusing the same blueprints. Use this
+when the set of DAGs is data-driven -- one per satellite, region, or tenant.

--- a/examples/advanced/dags/programmatic_dags.py
+++ b/examples/advanced/dags/programmatic_dags.py
@@ -1,0 +1,45 @@
+"""Build DAGs programmatically with the Builder API instead of YAML.
+
+Generates one telemetry DAG per satellite, reusing the blueprints in
+``blueprints.py``. ``DAGConfig`` takes the same fields you would write in YAML.
+"""
+
+from blueprint import Builder, DAGConfig
+
+SATELLITES = [
+    {"id": "SAT-001", "target": "Kepler-22b", "ground_station": "Madrid"},
+    {"id": "SAT-002", "target": "Proxima-b", "ground_station": "Goldstone"},
+    {"id": "SAT-003", "target": "TRAPPIST-1e", "ground_station": "Canberra"},
+]
+
+builder = Builder()
+
+for satellite in SATELLITES:
+    slug = satellite["id"].lower().replace("-", "_")
+
+    config = DAGConfig(
+        dag_id=f"telemetry_{slug}",
+        schedule="@hourly",
+        description=f"Telemetry pipeline for {satellite['id']}",
+        priority="high",
+        steps={
+            "scan": {
+                "blueprint": "scan",
+                "version": 1,
+                "target": satellite["target"],
+            },
+            "analyze": {
+                "blueprint": "analyze",
+                "depends_on": ["scan"],
+                "algorithms": ["fft", "matched_filter"],
+            },
+            "transmit": {
+                "blueprint": "transmit",
+                "depends_on": ["analyze"],
+                "destination": satellite["ground_station"],
+            },
+        },
+    )
+
+    dag = builder.build(config)
+    globals()[dag.dag_id] = dag


### PR DESCRIPTION
## What

Adds a runnable example demonstrating the `Builder` / `DAGConfig` programmatic API described in the README's [Programmatic Building](https://github.com/astronomer/blueprint#programmatic-building) section. 

## Changes

- **New:** `examples/advanced/dags/programmatic_dags.py`
- **Docs:** pointer from `README.md` to the example, plus mentions in `examples/README.md` and `examples/advanced/README.md`

## Verification

- The example executes and builds all three DAGs through the global registry (validated via `AIRFLOW_HOME`).
- `ruff check` and `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)