### PR TITLE
Emit templateType in blueprint schema output

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,8 @@ blueprint describe extract -v 1
 blueprint lint pipeline.dag.yaml
 
 # Generate JSON schema for editor support
+# (each schema includes a top-level "templateType" field — "blueprint" for a
+# step template, or "dag_args" for DAG-level fields via `blueprint schema --dag-args`)
 blueprint schema extract > extract.schema.json
 
 # Create new DAG interactively

--- a/blueprint/cli.py
+++ b/blueprint/cli.py
@@ -264,6 +264,7 @@ def _build_version_schema(
         schema_data["required"].insert(1, "version")
 
     schema_data["title"] = blueprint_name
+    schema_data["templateType"] = "blueprint"
     schema_data.pop("$schema", None)
 
     return schema_data
@@ -273,6 +274,7 @@ def _build_dag_yaml_schema(dag_args_schema: dict) -> dict:
     schema = copy.deepcopy(dag_args_schema)
     schema["$schema"] = "http://json-schema.org/draft-07/schema#"
     schema["title"] = "DAG"
+    schema["templateType"] = "dag_args"
     props = schema.setdefault("properties", {})
     props["dag_id"] = {"type": "string", "description": "Unique DAG identifier"}
     props["steps"] = {
@@ -349,6 +351,7 @@ def schema(
             schema_data = {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": blueprint_name,
+                "templateType": "blueprint",
                 "oneOf": variants,
                 "discriminator": {"propertyName": "version"},
             }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -243,6 +243,7 @@ class SchemaBlueprint(Blueprint[SchemaConfig]):
         assert "version" in result.output
         assert "$defs" not in result.output
         assert "$ref" not in result.output
+        assert json.loads(result.output)["templateType"] == "blueprint"
 
     def test_schema_command_multi_version(self, tmp_path):
         template_dir = tmp_path / "dags"
@@ -275,6 +276,9 @@ class FooV2(Blueprint[FooV2Config]):
         assert '"propertyName": "version"' in result.output
         assert "$defs" not in result.output
         assert "$ref" not in result.output
+        parsed = json.loads(result.output)
+        assert parsed["templateType"] == "blueprint"
+        assert all(variant["templateType"] == "blueprint" for variant in parsed["oneOf"])
 
     def test_schema_command_version_required(self, tmp_path):
         template_dir = tmp_path / "dags"
@@ -309,6 +313,7 @@ class Bar(Blueprint[BarConfig]):
         assert "schedule" in result.output
         assert "description" in result.output
         assert '"DAG"' in result.output
+        assert json.loads(result.output)["templateType"] == "dag_args"
 
     def test_schema_dag_args_custom(self, tmp_path):
         template_dir = tmp_path / "dags"
@@ -333,6 +338,7 @@ class CustomArgs(BlueprintDagArgs[CustomConfig]):
         assert "steps" in result.output
         assert "owner" in result.output
         assert "retries" in result.output
+        assert json.loads(result.output)["templateType"] == "dag_args"
 
     def test_schema_dag_args_with_blueprint_name_errors(self, tmp_path):
         template_dir = tmp_path / "dags"


### PR DESCRIPTION
## Context

`blueprint schema` emits JSON Schema for two distinct template types:

- **Step templates** (`Blueprint` subclasses) — `blueprint schema <name>`
- **DAG-level args** (`BlueprintDagArgs`) — `blueprint schema --dag-args`

Until now the only way to tell the two outputs apart was by inspecting `title` (blueprint name vs. the literal `"DAG"`) or by which fields were present (`blueprint`/`version` vs. `dag_id`/`steps`). There was no explicit, machine-readable marker of which template type a schema describes — awkward for IDEs, YAML language servers, and scripts that route/cache many schema files.

## Change

Adds a top-level `templateType` field to every emitted schema:

- step (blueprint) schemas → `"templateType": "blueprint"`
- DAG-args schemas → `"templateType": "dag_args"`

It's a plain JSON Schema keyword (not an `x-` OpenAPI extension) and uses JSON Schema's camelCase keyword convention, sitting alongside `title`, `oneOf`, etc. JSON Schema validators ignore unknown keywords, so it's safe for editor/language-server consumption.

In `blueprint/cli.py`:
- `_build_version_schema` sets `"blueprint"` (covers single-version output and each `oneOf` variant)
- `_build_dag_yaml_schema` sets `"dag_args"`
- the multi-version `oneOf` wrapper sets `"blueprint"` at the top level

## Tests

Added parsed-JSON assertions to the four schema tests in `tests/test_cli.py`, including verifying both the top-level wrapper and each variant in the multi-version case.

## Docs

Noted the new `templateType` field next to the `blueprint schema` example in `README.md`.

## Verification

- `ruff check` / `ruff format --check` / `ty check` — all pass
- `pytest tests/ --ignore=tests/integration` — 265 passed
- Live CLI against `examples/advanced/dags`: `analyze` → `blueprint`, `scan` (multi-version) → `blueprint` at top level and all variants, `--dag-args` → `dag_args`