### PR TITLE
Allow COLLABORATOR in Claude review gate

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,16 @@ on:
 
 jobs:
   claude-review:
-    # Safety: Only run for trusted contributors. COLLABORATOR is intentionally
-    # excluded — a single rogue/compromised collaborator could otherwise exfiltrate
-    # CLAUDE_CODE_OAUTH_TOKEN via the PR's pyproject.toml/uv.lock.
+    # Safety: only run for contributors with write access to the repo
+    # (OWNER/MEMBER/COLLABORATOR). External and fork contributors come through as
+    # CONTRIBUTOR/NONE and are skipped — and `pull_request` from a fork gets no
+    # secrets anyway, so CLAUDE_CODE_OAUTH_TOKEN is never exposed to untrusted code.
+    # MEMBER alone is insufficient: it only surfaces for *publicized* org membership,
+    # so privately-membered org members appear as COLLABORATOR.
     if: |
       github.event.pull_request.author_association == 'OWNER' ||
-      github.event.pull_request.author_association == 'MEMBER'
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Problem

The Claude Code Review workflow (`.github/workflows/claude-code-review.yml`) only runs its auto-review when the PR author's `author_association` is `OWNER` or `MEMBER`. In practice the job was being **skipped for our own contributors**.

Root cause: `author_association` reports `MEMBER` only when the author's **organization membership is publicized (public)**. With private org membership — our default — members surface as `COLLABORATOR` instead, so the gate evaluated false and the review never ran. (Observed on #59: same-repo PR, author has admin on the repo, but membership private → `author_association == COLLABORATOR` → skipped.)

## Change

Add `COLLABORATOR` to the gate so it keys off **repo write access** rather than public org-membership visibility:

```yaml
if: |
  github.event.pull_request.author_association == 'OWNER' ||
  github.event.pull_request.author_association == 'MEMBER' ||
  github.event.pull_request.author_association == 'COLLABORATOR'
```

## Why this is safe

- The trust boundary becomes "has push/write access to the repo." External and fork contributors come through as `CONTRIBUTOR`/`FIRST_TIME_CONTRIBUTOR`/`NONE` and are still skipped.
- For `pull_request` events **from forks, GitHub withholds secrets** (`CLAUDE_CODE_OAUTH_TOKEN` is empty, `GITHUB_TOKEN` is read-only), so the token is never exposed to untrusted/forked code regardless of the gate.
- The token-exfiltration concern in the original comment (malicious `pyproject.toml`/`uv.lock` build backend) only applies to same-repo PRs from people who already have write access — and is additionally mitigated by the existing `--disallowedTools` config that removes Bash/`uv`/write tools from the review run.

The inline comment is updated to explain the MEMBER-vs-COLLABORATOR distinction so this isn't reverted by mistake.