### PR TITLE
Post Claude review back to the PR via track_progress

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,6 +42,12 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+          # Post the review back to the PR. In automated/agent mode (a custom
+          # prompt with no @claude mention) the action posts nothing unless this
+          # is set — Claude's output would otherwise stay in the hidden action log.
+          # (use_sticky_comment does not work in agent mode for this version.)
+          track_progress: true
+
           # Prompt for automated review (no @claude mention needed)
           prompt: |
             Please review this pull request and provide feedback on:


### PR DESCRIPTION
## Problem

After fixing the gate (#60), the Claude Code Review job now runs on our PRs and **succeeds**, but it posts **no review comment**.

The execution log shows Claude initializing, running ~4 turns (`is_error: false`), then the final posting step printing **`No buffered inline comments`** and exiting. The review text was generated but went only to the action's log (which is hidden: *"full output hidden for security"*).

## Root cause

In `anthropics/claude-code-action@v1.0.131`, when triggered automatically (a custom `prompt` with no `@claude` mention — "agent mode"), the action does **not** create or update any PR comment by default. Claude's output stays internal. `use_sticky_comment` is **not effective in agent mode** for this version (action issues #1108 / #1052).

## Fix

Set `track_progress: true`, which makes the action post a tracking comment on the PR and write Claude's review into it. This is the reliable mechanism for automated reviews in v1.0.131.

```yaml
track_progress: true
```

No change to the security posture: posting uses the existing `pull-requests: write` `GITHUB_TOKEN`; the `--disallowedTools` list (no Edit/Write/git Bash) is unchanged, so the review run still cannot modify the PR.