### PR TITLE
Add -h and -v shorthands for --help and --version

### DIFF
--- a/blueprint/cli.py
+++ b/blueprint/cli.py
@@ -19,8 +19,8 @@ from blueprint.registry import BlueprintRegistry
 console = Console()
 
 
-@click.group()
-@click.version_option(package_name="airflow-blueprint")
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.version_option(None, "-v", "--version", package_name="airflow-blueprint")
 def cli():
     """Blueprint - Reusable task templates composed into Airflow DAGs.
 


### PR DESCRIPTION
`-h`:
```
uv run blueprint -h
Usage: blueprint [OPTIONS] COMMAND [ARGS]...

  Blueprint - Reusable task templates composed into Airflow DAGs.

  Define reusable blueprint classes in Python, compose them into DAGs with
  YAML, and let Blueprint handle validation and wiring.

Options:
  -v, --version  Show the version and exit.
  -h, --help     Show this message and exit.

Commands:
  describe  Show blueprint parameters and documentation.
  lint      Validate DAG YAML definitions.
  list      List available blueprints.
  new       Interactively create a new DAG YAML definition.
  schema    Generate JSON Schema for a blueprint's configuration.
```

`-v`:
```
uv run blueprint -v
blueprint, version 0.3.0
```