### PR TITLE
Show blueprint source path in `blueprint list`

### DIFF
--- a/blueprint/cli.py
+++ b/blueprint/cli.py
@@ -137,12 +137,12 @@ def list_blueprints(template_dir: str | None):
     table.add_column("Class", style="dim", no_wrap=False)
     table.add_column("Location", style="dim", overflow="fold")
 
-    cwd = Path.cwd()
+    base = Path(template_dir).resolve() if template_dir else Path.cwd()
     for bp in blueprints:
         versions_str = ", ".join(str(v) for v in bp["versions"])
         desc = bp["description"].split("\n")[0] if bp["description"] else "-"
         location = bp["locations"].get(bp["latest_version"])
-        location_str = display_path(location, base=cwd) if location else "-"
+        location_str = display_path(location, base=base) if location else "-"
         table.add_row(bp["name"], versions_str, desc, bp["class"], location_str)
 
     console.print(table)

--- a/blueprint/cli.py
+++ b/blueprint/cli.py
@@ -14,7 +14,7 @@ from rich.syntax import Syntax
 from rich.table import Table
 
 from blueprint.loaders import discover_blueprints, get_blueprint_info, validate_yaml
-from blueprint.registry import BlueprintRegistry
+from blueprint.registry import BlueprintRegistry, display_path
 
 console = Console()
 
@@ -134,11 +134,14 @@ def list_blueprints(template_dir: str | None):
     table.add_column("Versions", style="green", no_wrap=True)
     table.add_column("Description", overflow="fold")
     table.add_column("Class", style="dim", no_wrap=False)
+    table.add_column("Location", style="dim", overflow="fold")
 
     for bp in blueprints:
         versions_str = ", ".join(str(v) for v in bp["versions"])
         desc = bp["description"].split("\n")[0] if bp["description"] else "-"
-        table.add_row(bp["name"], versions_str, desc, bp["class"])
+        location = bp["locations"].get(bp["latest_version"])
+        location_str = display_path(location) if location else "-"
+        table.add_row(bp["name"], versions_str, desc, bp["class"], location_str)
 
     console.print(table)
 

--- a/blueprint/cli.py
+++ b/blueprint/cli.py
@@ -14,7 +14,8 @@ from rich.syntax import Syntax
 from rich.table import Table
 
 from blueprint.loaders import discover_blueprints, get_blueprint_info, validate_yaml
-from blueprint.registry import BlueprintRegistry, display_path
+from blueprint.registry import BlueprintRegistry
+from blueprint.utils import display_path
 
 console = Console()
 
@@ -136,11 +137,12 @@ def list_blueprints(template_dir: str | None):
     table.add_column("Class", style="dim", no_wrap=False)
     table.add_column("Location", style="dim", overflow="fold")
 
+    cwd = Path.cwd()
     for bp in blueprints:
         versions_str = ", ".join(str(v) for v in bp["versions"])
         desc = bp["description"].split("\n")[0] if bp["description"] else "-"
         location = bp["locations"].get(bp["latest_version"])
-        location_str = display_path(location) if location else "-"
+        location_str = display_path(location, base=cwd) if location else "-"
         table.add_row(bp["name"], versions_str, desc, bp["class"], location_str)
 
     console.print(table)

--- a/blueprint/errors.py
+++ b/blueprint/errors.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import yaml
 
+from blueprint.utils import display_path
+
 # Constants
 MAX_SUGGESTION_VALUES = 10
 
@@ -207,16 +209,18 @@ class DuplicateBlueprintError(BlueprintError):
     def __init__(self, blueprint_name: str, locations: list[str]):
         self.blueprint_name = blueprint_name
         self.locations = locations
+        super().__init__()
 
-        message = f"Duplicate blueprint name '{blueprint_name}' found in multiple locations:"
-        for loc in locations:
-            message += f"\n  • {loc}"
+    def __str__(self) -> str:
+        message = f"Duplicate blueprint name '{self.blueprint_name}' found in multiple locations:"
+        for loc in self.locations:
+            message += f"\n  • {display_path(loc)}"
 
         message += "\n\n💡 Suggestions:"
         message += "\n  • Rename one of the blueprint classes"
         message += "\n  • Use unique names for each blueprint"
 
-        super().__init__(message)
+        return message
 
 
 class DuplicateDAGIdError(BlueprintError):
@@ -276,15 +280,17 @@ class MultipleDagArgsError(BlueprintError):
 
     def __init__(self, locations: list[str]):
         self.locations = locations
+        super().__init__()
 
+    def __str__(self) -> str:
         message = "Multiple BlueprintDagArgs templates found. Only one is allowed per project:"
-        for loc in locations:
-            message += f"\n  • {loc}"
+        for loc in self.locations:
+            message += f"\n  • {display_path(loc) if loc else loc}"
 
         message += "\n\n💡 Suggestions:"
         message += "\n  • Remove all but one BlueprintDagArgs subclass"
 
-        super().__init__(message)
+        return message
 
 
 class InvalidVersionError(BlueprintError):

--- a/blueprint/errors.py
+++ b/blueprint/errors.py
@@ -209,7 +209,9 @@ class DuplicateBlueprintError(BlueprintError):
     def __init__(self, blueprint_name: str, locations: list[str]):
         self.blueprint_name = blueprint_name
         self.locations = locations
-        super().__init__()
+        # Pass raw args (not the rendered message) so repr() stays informative
+        # while __str__ renders cwd-relative paths lazily at display time.
+        super().__init__(blueprint_name, locations)
 
     def __str__(self) -> str:
         message = f"Duplicate blueprint name '{self.blueprint_name}' found in multiple locations:"
@@ -280,12 +282,14 @@ class MultipleDagArgsError(BlueprintError):
 
     def __init__(self, locations: list[str]):
         self.locations = locations
-        super().__init__()
+        super().__init__(locations)
 
     def __str__(self) -> str:
         message = "Multiple BlueprintDagArgs templates found. Only one is allowed per project:"
         for loc in self.locations:
-            message += f"\n  • {display_path(loc) if loc else loc}"
+            if not loc:
+                continue
+            message += f"\n  • {display_path(loc)}"
 
         message += "\n\n💡 Suggestions:"
         message += "\n  • Remove all but one BlueprintDagArgs subclass"

--- a/blueprint/registry.py
+++ b/blueprint/registry.py
@@ -22,6 +22,26 @@ logger = logging.getLogger(__name__)
 _BLUEPRINT_BASE_NAMES = frozenset({"Blueprint", "BlueprintDagArgs"})
 
 
+def display_path(path: str | Path) -> str:
+    """Render a path relative to the current working directory for display.
+
+    Falls back to the absolute path when it is not located under the working
+    directory (e.g. a sibling tree or a different drive on Windows).
+
+    Args:
+        path: Absolute or relative filesystem path.
+
+    Returns:
+        The path relative to ``Path.cwd()`` when it is below it, otherwise the
+        absolute path.
+    """
+    resolved = Path(path).resolve()
+    try:
+        return str(resolved.relative_to(Path.cwd()))
+    except ValueError:
+        return str(resolved)
+
+
 def _defines_blueprint_subclass(py_file: Path) -> bool:
     """Return True if the file's source defines a Blueprint or BlueprintDagArgs subclass.
 
@@ -150,28 +170,25 @@ class BlueprintRegistry:
                             and obj is not Blueprint
                             and obj.__module__ == module_name
                         ):
-                            self._register_class(obj, py_file, directory)
+                            self._register_class(obj, py_file)
                         elif (
                             isinstance(obj, type)
                             and issubclass(obj, BlueprintDagArgs)
                             and obj not in (BlueprintDagArgs, DefaultDagArgs)
                             and obj.__module__ == module_name
                         ):
-                            self._register_dag_args(obj, py_file, directory)
+                            self._register_dag_args(obj, py_file)
 
             except (DuplicateBlueprintError, MultipleDagArgsError, ValueError):
                 raise
             except (ImportError, SyntaxError) as e:
                 logger.warning("Failed to load %s: %s", py_file, e)
 
-    def _register_class(self, cls: type[Blueprint], py_file: Path, base_dir: Path) -> None:
+    def _register_class(self, cls: type[Blueprint], py_file: Path) -> None:
         """Register a blueprint class with its parsed name and version."""
         bp_name, version = cls.parse_name_and_version()
 
-        try:
-            location = str(py_file.relative_to(base_dir.parent.parent))
-        except ValueError:
-            location = str(py_file)
+        location = str(py_file.resolve())
 
         if bp_name not in self._blueprints:
             self._blueprints[bp_name] = {}
@@ -180,21 +197,20 @@ class BlueprintRegistry:
         if version in self._blueprints[bp_name]:
             existing_loc = self._blueprint_locations[bp_name][version]
             dup_name = f"{bp_name} (v{version})"
-            raise DuplicateBlueprintError(dup_name, [existing_loc, location])
+            raise DuplicateBlueprintError(
+                dup_name, [display_path(existing_loc), display_path(location)]
+            )
 
         self._blueprints[bp_name][version] = cls
         self._blueprint_locations[bp_name][version] = location
 
-    def _register_dag_args(
-        self, cls: type[BlueprintDagArgs], py_file: Path, base_dir: Path
-    ) -> None:
-        try:
-            location = str(py_file.relative_to(base_dir.parent.parent))
-        except ValueError:
-            location = str(py_file)
+    def _register_dag_args(self, cls: type[BlueprintDagArgs], py_file: Path) -> None:
+        location = str(py_file.resolve())
 
         if self._dag_args is not None:
-            raise MultipleDagArgsError([self._dag_args_location or "", location])
+            raise MultipleDagArgsError(
+                [display_path(self._dag_args_location or ""), display_path(location)]
+            )
 
         self._dag_args = cls
         self._dag_args_location = location

--- a/blueprint/registry.py
+++ b/blueprint/registry.py
@@ -22,26 +22,6 @@ logger = logging.getLogger(__name__)
 _BLUEPRINT_BASE_NAMES = frozenset({"Blueprint", "BlueprintDagArgs"})
 
 
-def display_path(path: str | Path) -> str:
-    """Render a path relative to the current working directory for display.
-
-    Falls back to the absolute path when it is not located under the working
-    directory (e.g. a sibling tree or a different drive on Windows).
-
-    Args:
-        path: Absolute or relative filesystem path.
-
-    Returns:
-        The path relative to ``Path.cwd()`` when it is below it, otherwise the
-        absolute path.
-    """
-    resolved = Path(path).resolve()
-    try:
-        return str(resolved.relative_to(Path.cwd()))
-    except ValueError:
-        return str(resolved)
-
-
 def _defines_blueprint_subclass(py_file: Path) -> bool:
     """Return True if the file's source defines a Blueprint or BlueprintDagArgs subclass.
 
@@ -197,20 +177,17 @@ class BlueprintRegistry:
         if version in self._blueprints[bp_name]:
             existing_loc = self._blueprint_locations[bp_name][version]
             dup_name = f"{bp_name} (v{version})"
-            raise DuplicateBlueprintError(
-                dup_name, [display_path(existing_loc), display_path(location)]
-            )
+            raise DuplicateBlueprintError(dup_name, [existing_loc, location])
 
         self._blueprints[bp_name][version] = cls
         self._blueprint_locations[bp_name][version] = location
 
     def _register_dag_args(self, cls: type[BlueprintDagArgs], py_file: Path) -> None:
+        """Register the single BlueprintDagArgs template, tracking its location."""
         location = str(py_file.resolve())
 
         if self._dag_args is not None:
-            raise MultipleDagArgsError(
-                [display_path(self._dag_args_location or ""), display_path(location)]
-            )
+            raise MultipleDagArgsError([self._dag_args_location or "", location])
 
         self._dag_args = cls
         self._dag_args_location = location

--- a/blueprint/utils.py
+++ b/blueprint/utils.py
@@ -1,0 +1,26 @@
+"""Common utilities shared across the blueprint package."""
+
+from pathlib import Path
+
+
+def display_path(path: str | Path, base: Path | None = None) -> str:
+    """Render a path relative to a base directory for display.
+
+    Falls back to the absolute path when it is not located under the base
+    directory (e.g. a sibling tree or a different drive on Windows).
+
+    Args:
+        path: Absolute or relative filesystem path.
+        base: Directory to render relative to. Defaults to the current working
+            directory, resolved at call time.
+
+    Returns:
+        The path relative to ``base`` when it is below it, otherwise the
+        absolute path.
+    """
+    base = (base or Path.cwd()).resolve()
+    resolved = Path(path).resolve()
+    try:
+        return str(resolved.relative_to(base))
+    except ValueError:
+        return str(resolved)

--- a/blueprint/utils.py
+++ b/blueprint/utils.py
@@ -16,8 +16,10 @@ def display_path(path: str | Path, base: Path | None = None) -> str:
 
     Returns:
         The path relative to ``base`` when it is below it, otherwise the
-        absolute path.
+        absolute path. A falsy ``path`` is returned unchanged.
     """
+    if not path:
+        return str(path)
     base = (base or Path.cwd()).resolve()
     resolved = Path(path).resolve()
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,7 +107,9 @@ class Foo(Blueprint[FooConfig]):
 
         assert result.exit_code == 0
         assert "Location" in result.output
-        assert "dags/bp.py" in result.output
+        # display_path renders with the OS separator, so build the expected
+        # path the same way rather than hard-coding a POSIX separator.
+        assert str(Path("dags") / "bp.py") in result.output
 
     def test_describe_command(self, tmp_path):
         template_dir = tmp_path / "dags"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for the Blueprint CLI."""
 
 import json
+from pathlib import Path
 
 from click.testing import CliRunner
 
@@ -79,6 +80,34 @@ class FooV2(Blueprint[FooV2Config]):
         assert "foo" in result.output.lower()
         assert "1" in result.output
         assert "2" in result.output
+
+    def test_list_shows_location(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            template_dir = Path("dags")
+            template_dir.mkdir()
+            (template_dir / "bp.py").write_text("""
+from pydantic import BaseModel
+from blueprint.core import Blueprint
+
+class FooConfig(BaseModel):
+    x: int = 1
+
+class Foo(Blueprint[FooConfig]):
+    '''Foo blueprint.'''
+    def render(self, config):
+        pass
+""")
+
+            result = runner.invoke(
+                cli,
+                ["list", "--template-dir", "dags"],
+                env={"COLUMNS": "200"},
+            )
+
+        assert result.exit_code == 0
+        assert "Location" in result.output
+        assert "dags/bp.py" in result.output
 
     def test_describe_command(self, tmp_path):
         template_dir = tmp_path / "dags"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,12 +81,13 @@ class FooV2(Blueprint[FooV2Config]):
         assert "1" in result.output
         assert "2" in result.output
 
-    def test_list_shows_location(self):
+    def test_list_location_is_relative_to_template_dir(self):
+        """When --template-dir is given, locations are shown relative to it."""
         runner = CliRunner()
         with runner.isolated_filesystem():
-            template_dir = Path("dags")
-            template_dir.mkdir()
-            (template_dir / "bp.py").write_text("""
+            nested = Path("dags") / "etl"
+            nested.mkdir(parents=True)
+            (nested / "bp.py").write_text("""
 from pydantic import BaseModel
 from blueprint.core import Blueprint
 
@@ -107,9 +108,10 @@ class Foo(Blueprint[FooConfig]):
 
         assert result.exit_code == 0
         assert "Location" in result.output
-        # display_path renders with the OS separator, so build the expected
-        # path the same way rather than hard-coding a POSIX separator.
-        assert str(Path("dags") / "bp.py") in result.output
+        # Relative to the template dir ("dags"), not cwd. display_path renders
+        # with the OS separator, so build the expected path the same way.
+        assert str(Path("etl") / "bp.py") in result.output
+        assert str(Path("dags") / "etl" / "bp.py") not in result.output
 
     def test_describe_command(self, tmp_path):
         template_dir = tmp_path / "dags"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -12,7 +12,7 @@ from blueprint.errors import (
     MultipleDagArgsError,
     NonContiguousVersionError,
 )
-from blueprint.registry import BlueprintRegistry, _defines_blueprint_subclass, display_path
+from blueprint.registry import BlueprintRegistry, _defines_blueprint_subclass
 
 
 class SimpleConfig(BaseModel):
@@ -677,20 +677,8 @@ class TestNonBlueprintFileFiltering:
         assert "etl" in bp_names
 
 
-class TestDisplayPath:
-    """Test the cwd-relative path renderer used for blueprint locations."""
-
-    def test_path_under_cwd_is_relative(self, tmp_path, monkeypatch):
-        monkeypatch.chdir(tmp_path)
-        nested = tmp_path / "dags" / "bp.py"
-        assert display_path(nested) == "dags/bp.py"
-
-    def test_path_outside_cwd_is_absolute(self, tmp_path, monkeypatch):
-        cwd = tmp_path / "project"
-        cwd.mkdir()
-        monkeypatch.chdir(cwd)
-        sibling = (tmp_path / "elsewhere" / "bp.py").resolve()
-        assert display_path(sibling) == str(sibling)
+class TestBlueprintLocations:
+    """Test how the registry tracks and reports blueprint source locations."""
 
     def test_list_blueprints_reports_absolute_location(self, tmp_path):
         template_dir = tmp_path / "dags"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,5 +1,7 @@
 """Tests for the version-aware Blueprint registry."""
 
+from pathlib import Path
+
 import pytest
 from pydantic import BaseModel
 
@@ -10,7 +12,7 @@ from blueprint.errors import (
     MultipleDagArgsError,
     NonContiguousVersionError,
 )
-from blueprint.registry import BlueprintRegistry, _defines_blueprint_subclass
+from blueprint.registry import BlueprintRegistry, _defines_blueprint_subclass, display_path
 
 
 class SimpleConfig(BaseModel):
@@ -673,3 +675,39 @@ class TestNonBlueprintFileFiltering:
 
         bp_names = [bp["name"] for bp in reg.list_blueprints()]
         assert "etl" in bp_names
+
+
+class TestDisplayPath:
+    """Test the cwd-relative path renderer used for blueprint locations."""
+
+    def test_path_under_cwd_is_relative(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        nested = tmp_path / "dags" / "bp.py"
+        assert display_path(nested) == "dags/bp.py"
+
+    def test_path_outside_cwd_is_absolute(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "project"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        sibling = (tmp_path / "elsewhere" / "bp.py").resolve()
+        assert display_path(sibling) == str(sibling)
+
+    def test_list_blueprints_reports_absolute_location(self, tmp_path):
+        template_dir = tmp_path / "dags"
+        template_dir.mkdir()
+        (template_dir / "etl.py").write_text(
+            "from pydantic import BaseModel\n"
+            "from blueprint.core import Blueprint\n"
+            "class Cfg(BaseModel):\n"
+            "    x: str = 'a'\n"
+            "class Etl(Blueprint[Cfg]):\n"
+            "    def render(self, config):\n"
+            "        pass\n"
+        )
+
+        reg = BlueprintRegistry(template_dirs=[template_dir])
+        reg.discover(force=True)
+
+        location = reg.list_blueprints()[0]["locations"][1]
+        assert Path(location).is_absolute()
+        assert Path(location) == (template_dir / "etl.py").resolve()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 """Tests for shared blueprint utilities."""
 
+from pathlib import Path
+
 from blueprint.utils import display_path
 
 
@@ -9,7 +11,9 @@ class TestDisplayPath:
     def test_path_under_cwd_is_relative(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         nested = tmp_path / "dags" / "bp.py"
-        assert display_path(nested) == "dags/bp.py"
+        nested.parent.mkdir()
+        nested.write_text("")
+        assert display_path(nested) == str(Path("dags") / "bp.py")
 
     def test_path_outside_cwd_is_absolute(self, tmp_path, monkeypatch):
         cwd = tmp_path / "project"
@@ -23,4 +27,4 @@ class TestDisplayPath:
         other.mkdir()
         monkeypatch.chdir(other)
         nested = tmp_path / "dags" / "bp.py"
-        assert display_path(nested, base=tmp_path) == "dags/bp.py"
+        assert display_path(nested, base=tmp_path) == str(Path("dags") / "bp.py")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,26 @@
+"""Tests for shared blueprint utilities."""
+
+from blueprint.utils import display_path
+
+
+class TestDisplayPath:
+    """Test the cwd-relative path renderer used for blueprint locations."""
+
+    def test_path_under_cwd_is_relative(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        nested = tmp_path / "dags" / "bp.py"
+        assert display_path(nested) == "dags/bp.py"
+
+    def test_path_outside_cwd_is_absolute(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "project"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        sibling = (tmp_path / "elsewhere" / "bp.py").resolve()
+        assert display_path(sibling) == str(sibling)
+
+    def test_explicit_base_overrides_cwd(self, tmp_path, monkeypatch):
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.chdir(other)
+        nested = tmp_path / "dags" / "bp.py"
+        assert display_path(nested, base=tmp_path) == "dags/bp.py"


### PR DESCRIPTION
## What

Adds a **Location** column to `blueprint list` so users can immediately see which file each blueprint is defined in.

- When `--template-dir DIR` is provided, the path is rendered **relative to `DIR`**.
- Otherwise it is rendered **relative to the current working directory**.

This addresses feedback that it was unclear where a given blueprint actually lives — the registry already tracked locations, but `blueprint list` never surfaced them.

## Example

```
$ blueprint list --template-dir examples/advanced/dags/

                              Available Blueprints
┏━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
┃ Name     ┃ Versions ┃ Description                   ┃ Class    ┃ Location       ┃
┡━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
│ analyze  │ 1        │ Run signal analysis ...       │ Analyze  │ blueprints.py  │
│ orbit    │ 1        │ Calculate and execute ...     │ Orbit    │ blueprints.py  │
│ scan     │ 1, 2     │ Multi-band scan with ...      │ ScanV2   │ blueprints.py  │
│ transmit │ 1        │ Transmit data to a ...        │ Transmit │ blueprints.py  │
└──────────┴──────────┴───────────────────────────────┴──────────┴────────────────┘
```

Here the locations are shown relative to the supplied `--template-dir` (so `blueprints.py` rather than `examples/advanced/dags/blueprints.py`). The shown path is the location of the **latest** version (matching the `Class` column).

## How

- The registry previously stored locations relative to an internal base directory, which is not meaningful when shown at the CLI. It now stores the **resolved absolute path**.
- New `blueprint/utils.py::display_path(path, base=None)` renders a path relative to `base` (defaulting to the cwd), falling back to the absolute path when the file is not under `base` (e.g. a sibling tree, or a different drive on Windows). The `list` command passes the resolved `--template-dir` as `base` when one is given.
- `DuplicateBlueprintError` / `MultipleDagArgsError` render their messages lazily in `__str__`, so locations are resolved relative to the cwd **at display time** rather than baked in when the error is raised. They pass their raw args to `super().__init__()` so `repr()` stays informative and the exceptions remain picklable.

## Tests

- `tests/test_utils.py::TestDisplayPath` — `display_path` under/outside the base, and the explicit-`base` override.
- `tests/test_registry.py::TestBlueprintLocations` — `list_blueprints()` reports absolute locations.
- `tests/test_cli.py::test_list_location_is_relative_to_template_dir` — the `Location` column renders relative to `--template-dir`.

All unit tests, `ruff`, and `ty` pass.
