### PR TITLE
Release v0.4.0

### DIFF
--- a/blueprint/__init__.py
+++ b/blueprint/__init__.py
@@ -1,6 +1,6 @@
 """Blueprint - Reusable task templates composed into Airflow DAGs via YAML."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 from .builder import (
     Builder,


### PR DESCRIPTION
Bumps the version to 0.4.0. New since v0.3.0:

- Respect `.airflowignore` when discovering DAG YAML files, in `build_all_airflow_dags` and `blueprint lint` (#67, fixes #66)
- Rename `build_all_dags` to `build_all_airflow_dags` so one-line loaders pass Airflow's safe-mode scanner; old names deprecated (#65)
- Show blueprint source path in `blueprint list` (#64)
- Add `-h` and `-v` shorthands for `--help` and `--version` (#63)

After merge, pushing the `v0.4.0` tag publishes to PyPI via the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J44AEQ8KTvUWxf6GnVRW66