### PR TITLE
Add argument for skipping invalid yamls instead of failing

### DIFF
--- a/blueprint/builder.py
+++ b/blueprint/builder.py
@@ -10,10 +10,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from blueprint.core import TaskOrGroup
 from blueprint.errors import (
+    BlueprintError,
     ConfigurationError,
     CyclicDependencyError,
     DuplicateDAGIdError,
@@ -503,6 +504,7 @@ def build_all_airflow_dags(
     template_context: dict[str, Any] | None = None,
     bp_registry: BlueprintRegistry | None = None,
     on_dag_built: OnDagBuilt | None = None,
+    skip_invalid_dags: bool = False,
 ) -> list["DAG"]:
     """Discover and build all DAGs from YAML files.
 
@@ -530,6 +532,9 @@ def build_all_airflow_dags(
         on_dag_built: Optional callback invoked after each DAG is built.
             Receives the DAG and the Path to the source YAML file.
             Use this to apply post-processing such as access controls or tags.
+        skip_invalid_dags: When True, log a warning and skip DAG files that fail
+            to parse or build instead of aborting the entire load. Valid DAGs are
+            still built and registered.
 
     Returns:
         List of built DAGs
@@ -568,36 +573,49 @@ def build_all_airflow_dags(
     dags: list[DAG] = []
     dag_id_to_file: dict[str, Path] = {}
 
+    skipped_files: set[str] = set()
     for yaml_path in yaml_files:
-        if render_templates:
-            raw_config, _rendered = render_yaml_template(
-                yaml_path, context=template_context, use_airflow_context=True
-            )
-        else:
-            raw_content = yaml_path.read_text()
-            raw_config = yaml.safe_load(raw_content)
+        try:
+            if render_templates:
+                raw_config, _rendered = render_yaml_template(
+                    yaml_path, context=template_context, use_airflow_context=True
+                )
+            else:
+                raw_content = yaml_path.read_text()
+                raw_config = yaml.safe_load(raw_content)
 
-        if not raw_config or "steps" not in raw_config:
-            logger.debug("Skipping %s: no 'steps' field", yaml_path.name)
-            continue
+            if not raw_config or "steps" not in raw_config:
+                logger.debug("Skipping %s: no 'steps' field", yaml_path.name)
+                continue
 
-        dag_config = DAGConfig.model_validate(raw_config)
-        _check_duplicate_dag_id(dag_config.dag_id, yaml_path, dag_id_to_file)
-        dag = builder.build(dag_config)
+            dag_config = DAGConfig.model_validate(raw_config)
+            _check_duplicate_dag_id(dag_config.dag_id, yaml_path, dag_id_to_file)
+            dag = builder.build(dag_config)
 
-        if on_dag_built:
-            on_dag_built(dag, yaml_path)
+            if on_dag_built:
+                on_dag_built(dag, yaml_path)
 
-        dag_id_to_file[dag.dag_id] = yaml_path
-        register_globals[dag.dag_id] = dag
-        dags.append(dag)
-        logger.info("Built DAG '%s' from %s", dag.dag_id, yaml_path.name)
+            dag_id_to_file[dag.dag_id] = yaml_path
+            register_globals[dag.dag_id] = dag
+            dags.append(dag)
+            logger.info("Built DAG '%s' from %s", dag.dag_id, yaml_path.name)
+        except (BlueprintError, ValidationError, yaml.YAMLError) as e:
+            if not skip_invalid_dags:
+                raise
+            skipped_files.add(str(yaml_path))
+            logger.warning("Skipping invalid file %s: %s", yaml_path, e)
 
     if dags:
         logger.info(
             "Successfully built %d DAG(s): %s",
             len(dags),
             ", ".join(d.dag_id for d in dags),
+        )
+    if skipped_files:
+        logger.warning(
+            "Skipped %d invalid DAG file(s); built %d DAG(s) successfully",
+            len(skipped_files),
+            len(dags),
         )
 
     return dags
@@ -611,6 +629,7 @@ def build_all_dags(
     template_context: dict[str, Any] | None = None,
     bp_registry: BlueprintRegistry | None = None,
     on_dag_built: OnDagBuilt | None = None,
+    skip_invalid_dags: bool = False,
 ) -> list["DAG"]:
     """Deprecated alias for ``build_all_airflow_dags``.
 
@@ -641,6 +660,7 @@ def build_all_dags(
         template_context=template_context,
         bp_registry=bp_registry,
         on_dag_built=on_dag_built,
+        skip_invalid_dags=skip_invalid_dags,
     )
 
 
@@ -652,6 +672,7 @@ def build_all(
     template_context: dict[str, Any] | None = None,
     bp_registry: BlueprintRegistry | None = None,
     on_dag_built: OnDagBuilt | None = None,
+    skip_invalid_dags: bool = False,
 ) -> list["DAG"]:
     """Deprecated alias for ``build_all_airflow_dags``."""
     warnings.warn(
@@ -674,6 +695,7 @@ def build_all(
         template_context=template_context,
         bp_registry=bp_registry,
         on_dag_built=on_dag_built,
+        skip_invalid_dags=skip_invalid_dags,
     )
 
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1080,6 +1080,144 @@ class Stub(Blueprint[StubConfig]):
                 render_templates=False,
             )
 
+    def test_skip_invalid_dags_builds_valid_ones(self, tmp_path):
+        from blueprint.builder import build_all_airflow_dags
+
+        bp_file = tmp_path / "blueprints.py"
+        bp_file.write_text("""
+from pydantic import BaseModel
+from blueprint.core import Blueprint
+
+class StubConfig(BaseModel):
+    x: int
+
+class Stub(Blueprint[StubConfig]):
+    def render(self, config):
+        from airflow.operators.bash import BashOperator
+        return BashOperator(task_id=self.step_id, bash_command="echo ok")
+""")
+
+        yaml_good = tmp_path / "good.dag.yaml"
+        yaml_good.write_text("""
+dag_id: good_dag
+steps:
+    step1:
+        blueprint: stub
+        x: 1
+""")
+
+        yaml_bad = tmp_path / "bad.dag.yaml"
+        yaml_bad.write_text("""
+dag_id: bad_dag
+steps:
+    step1:
+        blueprint: stub
+        y: 1
+""")
+
+        globals_dict = {}
+        dags = build_all_airflow_dags(
+            search_path=tmp_path,
+            register_globals=globals_dict,
+            render_templates=False,
+            skip_invalid_dags=True,
+        )
+        assert dags[0].dag_id == "good_dag"
+        assert "good_dag" in globals_dict
+        assert "bad_dag" not in globals_dict
+
+    def test_skip_invalid_dags_skips_invalid_yaml(self, tmp_path):
+        """Verify if valid yamls still return DAGs when invalid yamls are present."""
+        from blueprint.builder import build_all_airflow_dags
+
+        bp_file = tmp_path / "blueprints.py"
+        bp_file.write_text("""
+from pydantic import BaseModel
+from blueprint.core import Blueprint
+
+class StubConfig(BaseModel):
+    x: int = 1
+
+class Stub(Blueprint[StubConfig]):
+    def render(self, config):
+        from airflow.operators.bash import BashOperator
+        return BashOperator(task_id=self.step_id, bash_command="echo ok")
+""")
+
+        yaml_good = tmp_path / "good.dag.yaml"
+        yaml_good.write_text("dag_id: good_dag\nsteps:\n  s1:\n    blueprint: stub\n")
+
+        yaml_invalid = tmp_path / "invalid.dag.yaml"
+        yaml_invalid.write_text("dag_id: invalid_dag\nsteps: {}\n")
+
+        globals_dict = {}
+        dags = build_all_airflow_dags(
+            search_path=tmp_path,
+            register_globals=globals_dict,
+            render_templates=False,
+            skip_invalid_dags=True,
+        )
+        assert [dag.dag_id for dag in dags] == ["good_dag"]
+        assert "invalid_dag" not in globals_dict
+
+        # Rebuild, but now with skip_invalid_dags=False, and ensure it raises an exception
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            build_all_airflow_dags(
+                search_path=tmp_path,
+                register_globals=globals_dict,
+                render_templates=False,
+                skip_invalid_dags=False,
+            )
+
+    def test_skip_invalid_dags_skips_duplicate_dag_id(self, tmp_path):
+        """Verify if the first DAG is rendered with skip_invalid_dags=True."""
+        from blueprint.builder import build_all_airflow_dags
+
+        bp_file = tmp_path / "blueprints.py"
+        bp_file.write_text("""
+from pydantic import BaseModel
+from blueprint.core import Blueprint
+
+class StubConfig(BaseModel):
+    x: int = 1
+
+class Stub(Blueprint[StubConfig]):
+    def render(self, config):
+        from airflow.operators.bash import BashOperator
+        return BashOperator(task_id=self.step_id, bash_command="echo ok")
+""")
+
+        yaml1 = tmp_path / "first.dag.yaml"
+        yaml1.write_text("dag_id: dup_id\nsteps:\n  s1:\n    blueprint: stub\n")
+
+        yaml2 = tmp_path / "second.dag.yaml"
+        yaml2.write_text("dag_id: dup_id\nsteps:\n  s2:\n    blueprint: stub\n")
+
+        globals_dict = {}
+        dags = build_all_airflow_dags(
+            search_path=tmp_path,
+            register_globals=globals_dict,
+            render_templates=False,
+            skip_invalid_dags=True,
+        )
+        assert len(dags) == 1
+        assert dags[0].dag_id == "dup_id"
+        assert dags[0].leaves[0].task_id == "s1"
+        assert len(globals_dict) == 1
+
+        # Rebuild, but now with skip_invalid_dags=False, and ensure it raises a DuplicateDAGIdError
+        from blueprint.errors import DuplicateDAGIdError
+
+        with pytest.raises(DuplicateDAGIdError):
+            build_all_airflow_dags(
+                search_path=tmp_path,
+                register_globals=globals_dict,
+                render_templates=False,
+                skip_invalid_dags=False,
+            )
+
 
 class TestOnDagBuilt:
     def test_build_all_on_dag_built_called(self, tmp_path):


### PR DESCRIPTION
Issue: https://github.com/astronomer/blueprint/issues/70

This PR adds an argument `skip_invalid_dags`. With `build_all_airflow_dags(skip_invalid_dags=True)`, the builder will not fail upon parsing a faulty yaml file. Instead, it will continue to render valid yaml files.

The benefit is that 1 faulty YAML file doesn't take down other valid YAML files. The downside is that it's harder to find dag parsing errors. Since errors are not bubbled up via ImportErrors anymore (the loader.py will always parse correctly with `skip_invalid_dags=True`), those logs are now stored in `logs/dag_processor/latest/dags-folder/loader.py.log` in the DAG processor container.

Another edge case is duplicate dag ids: with `skip_invalid_dags=True`. when multiple dags have the same id they technically all parse correctly, but the first dag will now "survive" and consecutive dags will not be displayed.