### PR TITLE
Add CODEOWNERS assigning all paths to blueprint-maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @astronomer/blueprint-maintainers


### PR DESCRIPTION
The repo has no CODEOWNERS file, so pull requests open with no reviewer requested. A single blanket rule makes every path owned by `@astronomer/blueprint-maintainers`, so the team is auto-requested on every PR.

`.github/CODEOWNERS`:

```
* @astronomer/blueprint-maintainers
```
